### PR TITLE
最小化兼容处理

### DIFF
--- a/lualib-src/lua-skynet.c
+++ b/lualib-src/lua-skynet.c
@@ -32,9 +32,9 @@ struct stat {
 static void
 _stat_begin(struct stat *S, struct timespec *ti) {
 	S->count++;
-#if defined(_POSIX_TIMERS) && defined(_POSIX_THREAD_CPUTIME)
+#if !defined(__APPLE__)
 	clock_gettime(CLOCK_THREAD_CPUTIME_ID, ti);
-#elif  defined(__APPLE__)
+#else
 	struct task_thread_times_info aTaskInfo;
 	mach_msg_type_number_t aTaskInfoCount = TASK_THREAD_TIMES_INFO_COUNT;
 	assert(KERN_SUCCESS == task_info(mach_task_self(), TASK_THREAD_TIMES_INFO, (task_info_t )&aTaskInfo, &aTaskInfoCount));

--- a/lualib-src/trace_service.c
+++ b/lualib-src/trace_service.c
@@ -16,9 +16,9 @@
 void 
 diff_time(struct timespec *ti, uint32_t *sec, uint32_t *nsec) {
 	struct timespec end;
-#if defined(_POSIX_TIMERS) && defined(_POSIX_THREAD_CPUTIME)
+#if  !defined(__APPLE__)
 	clock_gettime(CLOCK_THREAD_CPUTIME_ID, &end);
-#elif  defined(__APPLE__)
+#else
 	struct task_thread_times_info aTaskInfo;
 	mach_msg_type_number_t aTaskInfoCount = TASK_THREAD_TIMES_INFO_COUNT;
 	assert(KERN_SUCCESS == task_info(mach_task_self(), TASK_THREAD_TIMES_INFO, (task_info_t )&aTaskInfo, &aTaskInfoCount));
@@ -89,9 +89,9 @@ trace_new(struct trace_pool *p) {
 	t->next = NULL;
 	t->ti_sec = 0;
 	t->ti_nsec = 0;
-#if defined(_POSIX_TIMERS) && defined(_POSIX_THREAD_CPUTIME)
+#if  !defined(__APPLE__)
 	clock_gettime(CLOCK_THREAD_CPUTIME_ID, &t->ti);
-#elif  defined(__APPLE__)
+#else
 	struct task_thread_times_info aTaskInfo;
 	mach_msg_type_number_t aTaskInfoCount = TASK_THREAD_TIMES_INFO_COUNT;
 	assert(KERN_SUCCESS == task_info(mach_task_self(), TASK_THREAD_TIMES_INFO, (task_info_t )&aTaskInfo, &aTaskInfoCount));
@@ -151,9 +151,9 @@ trace_switch(struct trace_pool *p, int session) {
 			if (t->next) {
 				t->next->prev = prev;
 			}
-#if defined(_POSIX_TIMERS) && defined(_POSIX_THREAD_CPUTIME)
+#if  !defined(__APPLE__)
 			clock_gettime(CLOCK_THREAD_CPUTIME_ID, &t->ti);
-#elif  defined(__APPLE__)
+#else
 			struct task_thread_times_info aTaskInfo;
 			mach_msg_type_number_t aTaskInfoCount = TASK_THREAD_TIMES_INFO_COUNT;
 			assert(KERN_SUCCESS == task_info(mach_task_self(), TASK_THREAD_TIMES_INFO, (task_info_t )&aTaskInfo, &aTaskInfoCount));

--- a/skynet-src/skynet_timer.c
+++ b/skynet-src/skynet_timer.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#if !defined(_POSIX_TIMERS)
+#if defined(__APPLE__)
 #include <sys/time.h>
 #endif
 
@@ -203,7 +203,7 @@ skynet_timeout(uint32_t handle, int time, int session) {
 static uint32_t
 _gettime(void) {
 	uint32_t t;
-#if defined(_POSIX_TIMERS)
+#if !defined(__APPLE__)
 	struct timespec ti;
 	clock_gettime(CLOCK_MONOTONIC, &ti);
 	t = (uint32_t)(ti.tv_sec & 0xffffff) * 100;
@@ -245,7 +245,7 @@ skynet_timer_init(void) {
 	TI = timer_create_timer();
 	TI->current = _gettime();
 
-#if defined(_POSIX_TIMERS)
+#if !defined(__APPLE__)
 	struct timespec ti;
 	clock_gettime(CLOCK_REALTIME, &ti);
 	uint32_t sec = (uint32_t)ti.tv_sec;


### PR DESCRIPTION
_POSIX_TIMERS & _POSIX_THREAD_CPUTIME 在 unistd.h 头文件定义，但并未包含。之前写法不正确，可以工作只是巧合。
现改为，默认使用 clock_gettime，当为 Max OSX 平台时，使用兼容方法。
