### PR TITLE
Update connection/connection.c

### DIFF
--- a/connection/connection.c
+++ b/connection/connection.c
@@ -101,7 +101,8 @@ connection_add(struct connection_pool * pool, int fd, void *ud) {
 void 
 connection_del(struct connection_pool * pool, int fd) {
 #if HAVE_EPOLL
-	epoll_ctl(pool->epoll_fd, EPOLL_CTL_DEL, fd , NULL);
+	struct epoll_event ev;
+	epoll_ctl(pool->epoll_fd, EPOLL_CTL_DEL, fd , &ev);
 #elif HAVE_KQUEUE
 	struct kevent ke;
 	EV_SET(&ke, fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);


### PR DESCRIPTION
according to "man epoll_ctl":
BUGS
       In kernel versions before 2.6.9, the EPOLL_CTL_DEL operation required a non-NULL pointer in event, even though this argument is ignored.  Since kernel  2.6.9,
       event can be specified as NULL when using EPOLL_CTL_DEL.
