### PR TITLE
config_log

### DIFF
--- a/service/main_log.lua
+++ b/service/main_log.lua
@@ -2,7 +2,8 @@ local skynet = require "skynet"
 
 skynet.start(function()
 	print("Log server start")
-	local connection = skynet.launch("connection","256")
+	-- local connection = skynet.launch("connection","256")
+	skynet.launch("socket",128)
 	local lualog = skynet.launch("snlua","lualog")
 	local console = skynet.launch("snlua","console")
 	local log = skynet.launch("snlua","globallog")


### PR DESCRIPTION
在启动console之前启动socket，不然console.lua调用socket.stdin()报错。
