### PR TITLE
optimize the search of empty slot in the hashid_node array

### DIFF
--- a/service-src/hashid.h
+++ b/service-src/hashid.h
@@ -19,12 +19,15 @@ struct hashid {
 };
 
 static void
-hashid_init(struct hashid *hi, int max, int hashcap) {
+hashid_init(struct hashid *hi, int max) {
 	int i;
-	assert((hashcap & (hashcap-1))==0);
-	hi->cap = max;
-	assert(hi->cap <= hashcap);
+	int hashcap;
+	hashcap = 16;
+	while (hashcap < max) {
+		hashcap *= 2;
+	}
 	hi->hashmod = hashcap - 1;
+	hi->cap = max;
 	hi->count = 0;
 	hi->id = malloc(max * sizeof(struct hashid_node));
 	for (i=0;i<max;i++) {

--- a/service-src/service_gate.c
+++ b/service-src/service_gate.c
@@ -368,11 +368,7 @@ gate_init(struct gate *g , struct skynet_context * ctx, char * parm) {
 
 	g->ctx = ctx;
 
-	int cap = 16;
-	while (cap < max) {
-		cap *= 2;
-	}
-	hashid_init(&g->hash, max, cap);
+	hashid_init(&g->hash, max);
 	g->conn = malloc(max * sizeof(struct connection));
 	memset(g->conn, 0, max *sizeof(struct connection));
 	g->max_connection = max;


### PR DESCRIPTION
As the players come and go, empty slots will appear evenly in the hashid_node array. If the search always starts from hi->count, new elments will be put in both ends, but the central part of the array will become sparse. And the following searches will be slowed down.
