### PR TITLE
bugfix: CLOCK_THREAD_CPUTIME_ID is not monotonic crossing scheduling thr...

### DIFF
--- a/lualib-src/trace_service.c
+++ b/lualib-src/trace_service.c
@@ -1,5 +1,4 @@
 #include "trace_service.h"
-#include "skynet_timer.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -27,13 +26,11 @@ current_time(struct timespec *ti) {
 #endif
 }
 
-void 
-diff_time(struct timespec *ti, uint32_t *sec, uint32_t *nsec) {
-	struct timespec end;
-	current_time(&end);
-	int diffsec = end.tv_sec - ti->tv_sec;
+static void
+_diff_time(struct timespec *ti, struct timespec *end, uint32_t *sec, uint32_t *nsec) {
+	int diffsec = end->tv_sec - ti->tv_sec;
 	assert(diffsec>=0);
-	int diffnsec = end.tv_nsec - ti->tv_nsec;
+	int diffnsec = end->tv_nsec - ti->tv_nsec;
 	if (diffnsec < 0) {
 		--diffsec;
 		diffnsec += NANOSEC;
@@ -46,14 +43,20 @@ diff_time(struct timespec *ti, uint32_t *sec, uint32_t *nsec) {
 	*sec += diffsec;
 }
 
+void 
+diff_time(struct timespec *ti, uint32_t *sec, uint32_t *nsec) {
+	struct timespec end;
+	current_time(&end);
+	_diff_time(ti, &end, sec, nsec);
+}
+
 struct trace_info {
 	int session;
 	struct trace_info * prev;
 	struct trace_info * next;
-	struct {
-		uint32_t elapsed;
-		uint32_t last;
-	} time;
+	struct timespec ti;
+	uint32_t ti_sec;
+	uint32_t ti_nsec;
 };
 
 struct trace_pool {
@@ -78,10 +81,16 @@ _free_slot(struct trace_info *t) {
 }
 
 static void
+_new_time(struct trace_info *t) {
+	current_time(&t->ti);
+}
+
+static void
 _save_time(struct trace_info *t) {
-	uint32_t now = skynet_gettime();
-	t->time.elapsed += now - t->time.last;
-	t->time.last = now;
+	struct timespec now;
+	current_time(&now);
+	_diff_time(&t->ti, &now, &t->ti_sec, &t->ti_nsec);
+	t->ti = now;
 }
 
 void
@@ -103,8 +112,9 @@ trace_new(struct trace_pool *p) {
 	t->session = 0;
 	t->prev = NULL;
 	t->next = NULL;
-	t->time.elapsed = 0;
-	t->time.last = skynet_gettime();
+	t->ti_sec = 0;
+	t->ti_nsec = 0;
+	_new_time(t);
 	return t;
 }
 
@@ -123,6 +133,7 @@ trace_register(struct trace_pool *p, int session) {
 		p->slot[hash]->prev = t;
 	}
 	p->slot[hash] = t;
+	_save_time(t);
 }
 
 struct trace_info * 
@@ -131,8 +142,9 @@ trace_yield(struct trace_pool *p) {
 	if (t == NULL)
 		return NULL;
 
+	_save_time(t);
+
 	if (t->session == 0) {
-		_save_time(t);
 		return t;
 	} else {
 		p->current = NULL;
@@ -157,6 +169,7 @@ trace_switch(struct trace_pool *p, int session) {
 			if (t->next) {
 				t->next->prev = prev;
 			}
+			_new_time(t);
 			return;
 		}
 		prev = t;
@@ -169,7 +182,7 @@ trace_delete(struct trace_pool *p, struct trace_info *t) {
 	assert(p->current == t);
 	p->current = NULL;
 	if (t) {
-		double ti = (double)t->time.elapsed/100;
+		double ti = (double)t->ti_sec + (double)t->ti_nsec / NANOSEC;
 		free(t);
 		return ti;
 	} else {


### PR DESCRIPTION
...eads

other issues in trace_service.c, fixed:
- trace_switch() reset current time without accumulating elapsed time
- trace_yield() accumulate elapsed time without resetting current time

test/testtrace.lua seems ok now.
