### PR TITLE
增加skynet易用性

### DIFF
--- a/lualib-src/lua-socket.c
+++ b/lualib-src/lua-socket.c
@@ -491,7 +491,7 @@ luaopen_socketdriver(lua_State *L) {
 	if (lua == NULL || lua->ctx == NULL) {
 		return luaL_error(L, "Init skynet context first");
 	}
-	assert(lua->L == L);
+	// assert(lua->L == L);
 	lua_pop(L,1);
 
 	lua_pushlightuserdata(L, lua->ctx);

--- a/lualib/skynet.lua
+++ b/lualib/skynet.lua
@@ -316,6 +316,10 @@ function skynet.ret(msg, sz)
 	coroutine_yield("RETURN", msg, sz)
 end
 
+function skynet.retpack(...)
+    return skynet.ret(skynet.pack(...))
+end
+
 function skynet.wakeup(co)
 	if sleep_session[co] and wakeup_session[co] == nil then
 		wakeup_session[co] = true
@@ -327,6 +331,17 @@ function skynet.dispatch(typename, func)
 	local p = assert(proto[typename],tostring(typename))
 	assert(p.dispatch == nil, tostring(typename))
 	p.dispatch = func
+end
+
+local function unknown_request(session, address, msg, sz)
+    print("Unknown request :" , c.tostring(msg,sz))
+	error(string.format("Unknown session : %d from %x", session, address))
+end
+
+function skynet.dispatch_unknown_request(unknown)
+    local prev = unknown_request
+    unknown_request = unknown
+    return prev
 end
 
 local function unknown_response(session, address, msg, sz)
@@ -352,7 +367,7 @@ function skynet.fork(func,...)
 	table.insert(fork_queue, co)
 end
 
-local function raw_dispatch_message(prototype, msg, sz, session, source)
+local function raw_dispatch_message(prototype, msg, sz, session, source, ...)
 	-- skynet.PTYPE_RESPONSE = 1, read skynet.h
 	if prototype == 1 then
 		local co = session_id_coroutine[session]
@@ -371,10 +386,9 @@ local function raw_dispatch_message(prototype, msg, sz, session, source)
 			local co = co_create(f)
 			session_coroutine_id[co] = session
 			session_coroutine_address[co] = source
-			suspend(co, coroutine.resume(co, session,source, p.unpack(msg,sz)))
+			suspend(co, coroutine.resume(co, session,source, p.unpack(msg,sz, ...)))
 		else
-			print("Unknown request :" , p.unpack(msg,sz))
-			error(string.format("Can't dispatch type %s : ", p.name))
+            unknown_request(session, source, msg, sz)
 		end
 	end
 end


### PR DESCRIPTION
1. 可以在服务运行中动态require socket
2. 添加方法skynet.retpack/skynet.dispatch_unknown_request
3. skynet.filter透传参数
