### PR TITLE
Bugfix: socket channel reconnect

### DIFF
--- a/lualib/mongo.lua
+++ b/lualib/mongo.lua
@@ -39,9 +39,7 @@ local client_meta = {
 
 		return "[mongo client : " .. self.host .. port_string .."]"
 	end,
-	__gc = function(self)
-		self:disconnect()
-	end
+	-- DO NOT need disconnect, because channel will shutdown during gc
 }
 
 local mongo_db = {}

--- a/lualib/redis.lua
+++ b/lualib/redis.lua
@@ -9,9 +9,7 @@ local redis = {}
 local command = {}
 local meta = {
 	__index = command,
-	__gc = function(self)
-		self[1]:close()
-	end,
+	-- DO NOT close channel in __gc
 }
 
 ---------- redis response

--- a/lualib/socket.lua
+++ b/lualib/socket.lua
@@ -30,6 +30,11 @@ local function suspend(s)
 	assert(not s.co)
 	s.co = coroutine.running()
 	skynet.wait()
+	-- wakeup closing corouting every time suspend,
+	-- because socket.close() will wait last socket buffer operation before clear the buffer.
+	if s.closing then
+		skynet.wakeup(s.closing)
+	end
 end
 
 -- read skynet_socket.h for these macro
@@ -102,6 +107,7 @@ socket_message[5] = function(id)
 		print("socket: error on", id)
 	end
 	s.connected = false
+
 	wakeup(s)
 end
 
@@ -175,7 +181,8 @@ function socket.close(id)
 		-- notice: call socket.close in __gc should be carefully,
 		-- because skynet.wait never return in __gc, so driver.clear may not be called
 		if s.co then
-			-- reading this socket on another coroutine
+			-- reading this socket on another coroutine, so don't shutdown (clear the buffer) immediatel
+			-- wait reading coroutine read the buffer.
 			assert(not s.closing)
 			s.closing = coroutine.running()
 			skynet.wait()
@@ -189,13 +196,6 @@ function socket.close(id)
 	socket_pool[id] = nil
 end
 
-local function close_socket(s)
-	if s.closing then
-		skynet.wakeup(s.closing)
-	end
-	return driver.readall(s.buffer, buffer_pool)
-end
-
 function socket.read(id, sz)
 	local s = socket_pool[id]
 	assert(s)
@@ -204,7 +204,7 @@ function socket.read(id, sz)
 		return ret
 	end
 	if not s.connected then
-		return false, close_socket(s)
+		return false, driver.readall(s.buffer, buffer_pool)
 	end
 
 	assert(not s.read_required)
@@ -214,7 +214,7 @@ function socket.read(id, sz)
 	if ret then
 		return ret
 	else
-		return false, close_socket(s)
+		return false, driver.readall(s.buffer, buffer_pool)
 	end
 end
 
@@ -222,14 +222,14 @@ function socket.readall(id)
 	local s = socket_pool[id]
 	assert(s)
 	if not s.connected then
-		local r = close_socket(s)
+		local r = driver.readall(s.buffer, buffer_pool)
 		return r ~= "" and r
 	end
 	assert(not s.read_required)
 	s.read_required = true
 	suspend(s)
 	assert(s.connected == false)
-	return close_socket(s)
+	return driver.readall(s.buffer, buffer_pool)
 end
 
 function socket.readline(id, sep)
@@ -241,7 +241,7 @@ function socket.readline(id, sep)
 		return ret
 	end
 	if not s.connected then
-		return false, close_socket(s)
+		return false, driver.readall(s.buffer, buffer_pool)
 	end
 	assert(not s.read_required)
 	s.read_required = sep
@@ -249,7 +249,7 @@ function socket.readline(id, sep)
 	if s.connected then
 		return driver.readline(s.buffer, buffer_pool, sep)
 	else
-		return false, close_socket(s)
+		return false, driver.readall(s.buffer, buffer_pool)
 	end
 end
 
@@ -261,9 +261,6 @@ function socket.block(id)
 	assert(not s.read_required)
 	s.read_required = 0
 	suspend(s)
-	if not s.connected and s.closing then
-		skynet.wakeup(s.closing)
-	end
 	return s.connected
 end
 


### PR DESCRIPTION
Two bugs in release v0.1.0
1. When socket disconnected, we should clear `__request` table.
2. Sometimes socket.close would block (It's a bug) , we should wake up closing coroutine after every suspend the reading . 

And, No `__gc` metamethod need in redis/mongo driver.
