### PR TITLE
lua service launch错误时，移除services中记录

### DIFF
--- a/service/launcher.lua
+++ b/service/launcher.lua
@@ -88,7 +88,7 @@ function command.ERROR(address)
 		skynet.redirect(reply.address , 0, "response", reply.session, "")
 		instance[address] = nil
 	end
-
+	services[address] = nil
 	return NORET
 end
 


### PR DESCRIPTION
lua service launch错误后,没有移除 launcher.lua里services中的服务记录，导致debug_console中的list mem等命令返回数据不正确
