### PR TITLE
Update rwlock.h

### DIFF
--- a/skynet-src/rwlock.h
+++ b/skynet-src/rwlock.h
@@ -16,7 +16,7 @@ static inline void
 rwlock_rlock(struct rwlock *lock) {
 	for (;;) {
 		while(lock->write) {
-			__sync_synchronize();
+			pthread_yield();
 		}
 		__sync_add_and_fetch(&lock->read,1);
 		if (lock->write) {
@@ -29,7 +29,9 @@ rwlock_rlock(struct rwlock *lock) {
 
 static inline void
 rwlock_wlock(struct rwlock *lock) {
-	while (__sync_lock_test_and_set(&lock->write,1)) {}
+	while (__sync_lock_test_and_set(&lock->write,1)) {
+		pthread_yield();
+	}
 	while(lock->read) {
 		__sync_synchronize();
 	}


### PR DESCRIPTION
读写锁在读线程数量多，读取很频繁的情况下，效率会变得很低：
 比如在一个环境里有100个线程读，1个线程写，假如写线程获取到write锁时，有80个线程再读（以获取写锁），假如在一个4核CPU上运行，那么write锁必须等到 80/4=20个单核读操作完成后，才能继续，而且这中间的竞争会很激烈，写锁会block所有后来读操作，这些线程相当于while（1）{}；很耗CPU，如果再获取不到write锁的时候，线程主动把cpu交出去，会减少很多竞争。
  普通状态下，如果写操作比较少，对性能影响有限。
