### PR TITLE
Ignore DS_Store file for Mac OS X users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /luaclib
 *.so
 *.dSYM
+.DS_Store


### PR DESCRIPTION
I'm a Mac OS X user. Adding this ignore setting is good for other Mac OS X users to commit changes without disturbing of .DS_Store files.
