### PR TITLE
bugfix: skynet.sleep return string

### DIFF
--- a/lualib/skynet.lua
+++ b/lualib/skynet.lua
@@ -122,7 +122,7 @@ local function dispatch_wakeup()
 		local session = sleep_session[co]
 		if session then
 			session_id_coroutine[session] = "BREAK"
-			return suspend(co, coroutine.resume(co, true))
+			return suspend(co, coroutine.resume(co, false))
 		end
 	end
 end
@@ -244,9 +244,9 @@ function skynet.sleep(ti)
 	local session = c.command("TIMEOUT",tostring(ti))
 	assert(session)
 	session = tonumber(session)
-	local succ, ret = coroutine_yield("SLEEP", session)
+	local ret = coroutine_yield("SLEEP", session)
 	sleep_session[coroutine.running()] = nil
-	if ret == true then
+	if ret == false then
 		return "BREAK"
 	end
 end


### PR DESCRIPTION
我在测试testtimer.lua的时候发现skynet.sleep 返回的字符串可能有问题。按照我的理解，如果是wakeup打断的sleep应该返回BREAK，但并没有返回。
