### PR TITLE
avoid potential memory leakage.

### DIFF
--- a/skynet-src/skynet_socket.c
+++ b/skynet-src/skynet_socket.c
@@ -47,7 +47,7 @@ forward_message(int type, bool padding, struct socket_message * result) {
 	sm->ud = result->ud;
 	if (padding) {
 		sm->buffer = NULL;
-		strcpy((char*)(sm+1), result->data);
+		strncpy((char*)(sm+1), result->data, strlen(result->data));
 	} else {
 		sm->buffer = result->data;
 	}


### PR DESCRIPTION
If not packing '\0' into the message then maybe we should be careful when strcpy() between strings. Current implementation may cause memory leakage somehow?
