### PR TITLE
扩展mongodb库功能

### DIFF
--- a/lualib/mongo.lua
+++ b/lualib/mongo.lua
@@ -227,7 +227,11 @@ function mongo_collection:insert(doc)
 	sock:request(pack)
 end
 
-function mongo_collection:batch_insert(docs)
+function mongo_collection:safe_insert(doc)
+	return self.database:runCommand("insert", self.name, "documents", {bson_encode(doc)})	
+end
+
+function mongo_collection:batch_insert(docs)		
 	for	i=1,#docs do
 		if docs[i]._id == nil then
 			docs[i]._id	= bson.objectid()
@@ -274,6 +278,48 @@ function mongo_collection:find(query, selector)
 		__document = {},
 		__flags	= 0,
 	} ,	cursor_meta)
+end
+
+-- collection:createIndex({username = 1}, {unique = true})
+function mongo_collection:createIndex(keys, option)
+	local name
+	for k, v in pairs(keys) do
+		assert(v == 1)
+		name = (name == nil) and k or (name .. "_" .. k)
+	end
+
+	local doc = {};
+	doc.name = name
+	doc.key = keys
+	for k, v in pairs(option) do
+		if v then
+			doc[k] = true
+		end
+	end
+	return self.database:runCommand("createIndexes", self.name, "indexes", {doc})
+end
+
+mongo_collection.ensureIndex = mongo_collection.createIndex;
+
+-- collection:findAndModify({query = {name = "userid"}, update = {["$inc"] = {nextid = 1}}, })
+-- keys, value type
+-- query, table	
+-- sort, table
+-- remove, bool 
+-- update, table 
+-- new, bool 
+-- fields, bool 
+-- upsert, boolean 
+function mongo_collection:findAndModify(doc)
+	assert(doc.query)
+	assert(doc.update or doc.remove)
+
+	local cmd = {"findAndModify", self.name};
+	for k, v in pairs(doc) do
+		table.insert(cmd, k)
+		table.insert(cmd, v)
+	end
+	return self.database:runCommand(unpack(cmd))
 end
 
 function mongo_cursor:hasNext()


### PR DESCRIPTION
1、mongo_collection:createIndex 创建索引
2、mongo_collection:safe_insert 可以判断返回值的insert
3、mongo_collection:findAndModify 查询并修改

仿照 https://github.com/mongodb/mongo-c-driver 写的

接口文档 http://docs.mongodb.org/manual/reference/method/js-collection/

ensure_index 和 create_index 两个名字是因为文档上有两个接口，C用的一套实现，索性就抄过来了
https://github.com/mongodb/mongo-c-driver/blob/master/src/mongoc/mongoc-collection.c

```
bool
mongoc_collection_ensure_index (mongoc_collection_t      *collection,
                                const bson_t             *keys,
                                const mongoc_index_opt_t *opt,
                                bson_error_t             *error)
{
   return mongoc_collection_create_index (collection, keys, opt, error);
}
```
