### PR TITLE
'pack' freed  before  'yield' return  during channel message dispatch

### DIFF
--- a/lualib-src/lua-multicast.c
+++ b/lualib-src/lua-multicast.c
@@ -134,7 +134,7 @@ mc_closelocal(lua_State *L) {
 static int
 mc_closelocal_pack(lua_State *L) {
 	struct mc_package *pack = lua_touserdata(L,1);
-	return closelocal_pack(pack);
+	return closelocal_pack(L, pack);
 }
 
 /*

--- a/lualib/multicast.lua
+++ b/lualib/multicast.lua
@@ -78,6 +78,7 @@ local function dispatch_subscribe(channel, source, pack, msg, sz)
 	end
 
 	if self.__subscribe then
+		-- may yield in dispatch
 		local ok, err = pcall(self.__dispatch, self, source, self.__unpack(msg, sz))
 		mc.close_pack(pack)
 		assert(ok, err)

--- a/lualib/multicast.lua
+++ b/lualib/multicast.lua
@@ -73,17 +73,17 @@ end
 local function dispatch_subscribe(channel, source, pack, msg, sz)
 	local self = dispatch[channel]
 	if not self then
-		mc.close(pack)
+		mc.close_pack(pack)
 		error ("Unknown channel " .. channel)
 	end
 
 	if self.__subscribe then
 		local ok, err = pcall(self.__dispatch, self, source, self.__unpack(msg, sz))
-		mc.close(pack)
+		mc.close_pack(pack)
 		assert(ok, err)
 	else
 		-- maybe unsubscribe first, but the message is send out. drop the message unneed
-		mc.close(pack)
+		mc.close_pack(pack)
 	end
 end
 


### PR DESCRIPTION
When there is a 'yield'  in a channel message dispatch function,  the 'pack'  is freed after the message dispatch,  but the invalid address is left for  'mc.close'  call in lua. Maybe there is better change method instead of adding new function.