### PR TITLE
修正了 Lua53 下 telnet 的 mem 指令报错

### DIFF
--- a/service/launcher.lua
+++ b/service/launcher.lua
@@ -41,7 +41,7 @@ function command.MEM()
 	local list = {}
 	for k,v in pairs(services) do
 		local kb, bytes = skynet.call(k,"debug","MEM")
-		list[skynet.address(k)] = string.format("%d Kb (%s)",kb,v)
+		list[skynet.address(k)] = string.format("%.2f Kb (%s)",kb,v)
 	end
 	return list
 end


### PR DESCRIPTION
在 Lua53 分支下，通过 telnet 连接到 debug_console 后，发出 mem 指令会导致 string.format() 报错：
./service/launcher.lua:46: bad argument #2 to 'format' (number has no integer representation)

Lua52 下没事，所以我改了一下这个指令输出的格式。