### PR TITLE
snax 的 G 可配置

### DIFF
--- a/examples/config
+++ b/examples/config
@@ -12,5 +12,6 @@ luaservice = root.."service/?.lua;"..root.."test/?.lua;"..root.."examples/?.lua"
 lualoader = "lualib/loader.lua"
 -- preload = "./examples/preload.lua"	-- run preload.lua before every lua service run
 snax = root.."examples/?.lua;"..root.."test/?.lua"
+-- snax_interface_g = "snax_g"
 cpath = root.."cservice/?.so"
 -- daemon = "./skynet.pid"

--- a/lualib/snax.lua
+++ b/lualib/snax.lua
@@ -4,7 +4,9 @@ local snax_interface = require "snax.interface"
 local snax = {}
 local typeclass = {}
 
-local G = { require = function() end }
+local interface_g = skynet.getenv("snax_interface_g")
+local G = interface_g and require (interface_g) or { require = function() end }
+interface_g = nil
 
 skynet.register_protocol {
 	name = "snax",


### PR DESCRIPTION
1、我们新增了一些辅助函数，会在全局调用，比如说解决重复包含的delayrequire，所以想把snax的G改为可配置的，这样在升级skynet的时候，不需要合并代码
2、修改配置项为 snax_interface_g 你若感觉命名不好，我们在讨论
3、你说的 “只取一次 skynet.getenv, 然后用 if else”，我只写改了只取一次 skynet.getenv，“用 if else”我尝试了一下，感觉太丑了，不符合我对代码的审美观，但是你如果坚持，我也可以改过来