### PR TITLE
fix:udp and udp_send

### DIFF
--- a/lualib-src/lua-socket.c
+++ b/lualib-src/lua-socket.c
@@ -599,7 +599,9 @@ static int
 ludp_address(lua_State *L) {
 	size_t sz = 0;
 	const uint8_t * addr = (const uint8_t *)luaL_checklstring(L, 1, &sz);
-	int port = addr[1] * 256 + addr[2];
+	uint16_t port = 0;
+	memcpy(&port, addr+1, sizeof(uint16_t));
+	port = ntohs(port);
 	const void * src = addr+3;
 	char tmp[256];
 	int family;

--- a/skynet-src/socket_server.c
+++ b/skynet-src/socket_server.c
@@ -720,6 +720,7 @@ send_socket(struct socket_server *ss, struct request_send * request, struct sock
 				append_sendbuffer_udp(ss,s,priority,request,udp_address);
 			} else {
 				so.free_func(request->buffer);
+				return -1;
 			}
 		}
 		sp_write(ss->event_fd, s->fd, s, true);
@@ -887,6 +888,7 @@ add_udp_socket(struct socket_server *ss, struct request_udp *udp) {
 	if (ns == NULL) {
 		close(udp->fd);
 		ss->slot[HASH_ID(id)].type = SOCKET_TYPE_INVALID;
+		return;
 	}
 	ns->type = SOCKET_TYPE_CONNECTED;
 	memset(ns->p.udp_address, 0, sizeof(ns->p.udp_address));


### PR DESCRIPTION
send_socket里面udp数据成功发送的情况下，不需要再调sp_write；
add_udp_socket里面ns为NULL得return，否则后面有空指针引用