### PR TITLE
'hotfix' code cannot use '_ENV'

### DIFF
--- a/lualib/snax/hotfix.lua
+++ b/lualib/snax/hotfix.lua
@@ -49,7 +49,9 @@ local function collect_all_uv(funcs)
 			collect_uv(v[4], global, envid(v[4]))
 		end
 	end
-
+	if not global["_ENV"] then
+		global["_ENV"] = {func = collect_uv, index = 1}
+	end
 	return global
 end
 


### PR DESCRIPTION
If there's no global variable or function used in any interface of a snax service,the upvalue "_ENV" for 'hotfix' is not set. This modify is not  complete, it depend's on the 'collect_uv' method having upvalue '_ENV',maybe other good method to get upvalue index of '_ENV'.