### PR TITLE
'skynet_socket_message'  not terminated by '\0'

### DIFF
--- a/skynet-src/skynet_socket.c
+++ b/skynet-src/skynet_socket.c
@@ -36,7 +36,7 @@ forward_message(int type, bool padding, struct socket_message * result) {
 	size_t sz = sizeof(*sm);
 	if (padding) {
 		if (result->data) {
-			sz += strlen(result->data);
+			sz += (strlen(result->data) + 1);
 		} else {
 			result->data = "";
 		}


### PR DESCRIPTION
'skynet_socket_message' buffer is used as common string  terminated by '\0' for ACCEPT and OPEN,maybe it's better to keep '\0' at end