### PR TITLE
从check_wsz发送的SKYNET_SOCKET_TYPE_WARNING消息会assert失败，导致coredump

### DIFF
--- a/service-src/service_gate.c
+++ b/service-src/service_gate.c
@@ -295,7 +295,6 @@ _cb(struct skynet_context * ctx, void * ud, int type, int session, uint32_t sour
 		}
 	}
 	case PTYPE_SOCKET:
-		assert(source == 0);
 		// recv socket message from skynet_socket
 		dispatch_socket_message(g, msg, (int)(sz-sizeof(struct skynet_socket_message)));
 		break;


### PR DESCRIPTION
从check_wsz发送的SKYNET_SOCKET_TYPE_WARNING消息会assert失败，导致coredump