### PR TITLE
Update socket_server.c

### DIFF
--- a/skynet-src/socket_server.c
+++ b/skynet-src/socket_server.c
@@ -1403,6 +1403,9 @@ do_bind(const char *host, int port, int protocol, int *family) {
 	if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (void *)&reuse, sizeof(int))==-1) {
 		goto _failed;
 	}
+	if (fcntl(fd, F_SETFD, FD_CLOEXEC)) {
+		goto _failed;
+	}
 	status = bind(fd, (struct sockaddr *)ai_list->ai_addr, ai_list->ai_addrlen);
 	if (status != 0)
 		goto _failed;


### PR DESCRIPTION
防止在 skynet 系统中启动子进程的时候复制自身打开的 socket 描述符.