### PR TITLE
服务器执行shutdown流程关闭gate服务后，后续的客户端登入会使login服务报错。

### DIFF
--- a/lualib/snax/loginserver.lua
+++ b/lualib/snax/loginserver.lua
@@ -173,7 +173,7 @@ local function launch_master(conf)
 			if err ~= socket_error then
 				skynet.error(string.format("invalid client (fd = %d) error = %s", fd, err))
 			end
-			socket.start(fd)
+			pcall(socket.start, fd)
 		end
 		socket.close(fd)
 	end)


### PR DESCRIPTION
原因是fd已经是有效的，再次调用socket.start会抛出错误。所以要么使用pcall调用，要么做下判定，如下：
if err ~= socket_error then
 skynet.error(string.format("invalid client (fd = %d) error = %s", fd, err))
else
 socket.start(fd)
end