### PR TITLE
loginserver.lua中的launch_slave的lua消息处理函数的return问题

### DIFF
--- a/lualib/snax/loginserver.lua
+++ b/lualib/snax/loginserver.lua
@@ -106,9 +106,9 @@ local function launch_slave(auth_handler)
 	skynet.dispatch("lua", function(_,_,...)
 		local ok, msg, len = pcall(auth_fd, ...)
 		if ok then
-			return skynet.ret(msg,len)
+			skynet.ret(msg,len)
 		else
-			return skynet.ret(skynet.pack(false, msg))
+			skynet.ret(skynet.pack(false, msg))
 		end
 	end)
 end


### PR DESCRIPTION
之前可能是我没有表述清楚，这两个return我猜想是不是手误加上去的，因为之前都没有见过需要在消息处理函数里面return skynet.ret调用的结果，实际去掉后测试也是没有问题的，和是不是两次pcall的调用应该是没有关系的。