### PR TITLE
Fix dangling c pointer to lua string value

### DIFF
--- a/lualib-src/lua-seri.c
+++ b/lualib-src/lua-seri.c
@@ -572,7 +572,7 @@ _luaseri_unpack(lua_State *L) {
 		return luaL_error(L, "deserialize null pointer");
 	}
 
-	lua_settop(L,0);
+	lua_settop(L,1);
 	struct read_block rb;
 	rball_init(&rb, buffer, len);
 
@@ -591,7 +591,7 @@ _luaseri_unpack(lua_State *L) {
 
 	// Need not free buffer
 
-	return lua_gettop(L);
+	return lua_gettop(L) - 1;
 }
 
 int


### PR DESCRIPTION
Lua string object referenced by C pointer from lua_tolstring() was
removed from stack by lua_settop(L,0).

Lua 5.3 Reference Manual says:

> Because Lua has garbage collection, there is no guarantee that the
> pointer returned by lua_tolstring will be valid after the
> corresponding Lua value is removed from the stack.

That is it.

Introduced in commit 9937081854c7b65d0a0557c3630ecbf1d62622d8.