### PR TITLE
memory size exceed max lua_Integer, improve some log description

### DIFF
--- a/lualib-src/lua-memory.c
+++ b/lualib-src/lua-memory.c
@@ -7,7 +7,7 @@
 static int
 ltotal(lua_State *L) {
 	size_t t = malloc_used_memory();
-	lua_pushinteger(L, (lua_Integer)t);
+	lua_pushnumber(L, t);
 
 	return 1;
 }
@@ -15,7 +15,7 @@ ltotal(lua_State *L) {
 static int
 lblock(lua_State *L) {
 	size_t t = malloc_memory_block();
-	lua_pushinteger(L, (lua_Integer)t);
+	lua_pushnumber(L, t);
 
 	return 1;
 }

--- a/service/cmemory.lua
+++ b/service/cmemory.lua
@@ -8,7 +8,7 @@ for k,v in pairs(info) do
 	print(string.format(":%08x %gK",k,v/1024))
 end
 
-print("Total memory:", memory.total())
-print("Total block:", memory.block())
+print("Total c memory:", memory.total())
+print("Total c block:", memory.block())
 
 skynet.start(function() skynet.exit() end)

--- a/skynet-src/malloc_hook.c
+++ b/skynet-src/malloc_hook.c
@@ -206,7 +206,7 @@ void
 dump_c_mem() {
 	int i;
 	size_t total = 0;
-	skynet_error(NULL, "dump all service mem:");
+	skynet_error(NULL, "dump all service c mem:");
 	for(i=0; i<SLOT_SIZE; i++) {
 		mem_data* data = &mem_stats[i];
 		if(data->handle != 0 && data->allocated != 0) {
@@ -214,7 +214,7 @@ dump_c_mem() {
 			skynet_error(NULL, "0x%x -> %zdkb", data->handle, data->allocated >> 10);
 		}
 	}
-	skynet_error(NULL, "+total: %zdkb",total >> 10);
+	skynet_error(NULL, "+total c mem: %zdkb",total >> 10);
 }
 
 char *


### PR DESCRIPTION
memory size may exceed max lua_Integer. 'malloc_hook' doesn't account for lua memory now, so improve some log descriptions for easy understand