### PR TITLE
fix a debug_console error

### DIFF
--- a/service/debug_console.lua
+++ b/service/debug_console.lua
@@ -231,7 +231,7 @@ function COMMAND.debug(address, fd)
 	skynet.fork(function()
 		repeat
 			local cmdline = socket.readline(fd, "\n")
-            cmdline = cmdline:gsub("(.*)\r$", "%1")
+            cmdline = cmdline and cmdline:gsub("(.*)\r$", "%1")
 			if not cmdline then
 				skynet.send(agent, "lua", "cmd", "cont")
 				break
@@ -275,5 +275,3 @@ function COMMAND.shrtbl()
 	local n, total, longest, space = memory.ssinfo()
 	return { n = n, total = total, longest = longest, space = space }
 end
-
-

--- a/service/debug_console.lua
+++ b/service/debug_console.lua
@@ -231,7 +231,7 @@ function COMMAND.debug(address, fd)
 	skynet.fork(function()
 		repeat
 			local cmdline = socket.readline(fd, "\n")
-            cmdline = cmdline and cmdline:gsub("(.*)\r$", "%1")
+			cmdline = cmdline and cmdline:gsub("(.*)\r$", "%1")
 			if not cmdline then
 				skynet.send(agent, "lua", "cmd", "cont")
 				break


### PR DESCRIPTION
[:00000009] lua call [0 to :9 : 0 msgsz = 24] error : [31mlua/lualib/skynet.lua:521: lua/lualib/skynet.lua:155: lua/service/debug_console.lua:234: attempt to index a boolean value (local 'cmdline')
stack traceback:
	lua/service/debug_console.lua:234: in upvalue 'func'
	lua/lualib/skynet.lua:457: in upvalue 'f'
	lua/lualib/skynet.lua:109: in function <lua/lualib/skynet.lua:103>
stack traceback:
	[C]: in function 'assert'
	lua/lualib/skynet.lua:521: in function 'skynet.dispatch_message'[0m
