### PR TITLE
No need to use while loop because link is cleared

### DIFF
--- a/skynet-src/skynet_timer.c
+++ b/skynet-src/skynet_timer.c
@@ -157,7 +157,7 @@ static inline void
 timer_execute(struct timer *T) {
 	int idx = T->time & TIME_NEAR_MASK;
 	
-	while (T->near[idx].head.next) {
+	if (T->near[idx].head.next) {
 		struct timer_node *current = link_clear(&T->near[idx]);
 		SPIN_UNLOCK(T);
 		// dispatch_list don't need lock T


### PR DESCRIPTION
```c
T->near[idx].head.next
```
会在link_clear后变为0，不需要使用while。