### PR TITLE
reduce needless 'add_string' call

### DIFF
--- a/3rd/lua/lstring.c
+++ b/3rd/lua/lstring.c
@@ -419,8 +419,11 @@ luaS_clonestring(lua_State *L, TString *ts) {
   result = query_ptr(ts);
   if (result)
     return result;
-  // ts is not in SSM, so recalc hash, and add it to SSM
   h = luaS_hash(str, l, 0);
+  result = query_string(h, str, l);
+  if (result)
+    return result;
+  // ts is not in SSM, so recalc hash, and add it to SSM
   return add_string(h, str, l);
 }
 


### PR DESCRIPTION
Short strings in lua proto are reused most of the time. The string in SSM may be added by one service and used by other service,  there is no need to call `add_string`,which will call 'new_string' first.