### PR TITLE
cluster.call can use service register name

### DIFF
--- a/service/clusterd.lua
+++ b/service/clusterd.lua
@@ -150,7 +150,7 @@ function command.socket(source, subcmd, fd, msg)
 			end
 		else
 			if type(addr) == "string" then
-				addr = register_name[addr]
+				addr = register_name[addr] or addr
 			end
 			ok , msg, sz = pcall(skynet.rawcall, addr, "lua", msg, sz)
 		end

--- a/service/clusterd.lua
+++ b/service/clusterd.lua
@@ -149,6 +149,9 @@ function command.socket(source, subcmd, fd, msg)
 				msg = "name not found"
 			end
 		else
+			if type(addr) == "string" then
+				addr = register_name[addr]
+			end
 			ok , msg, sz = pcall(skynet.rawcall, addr, "lua", msg, sz)
 		end
 		if ok then


### PR DESCRIPTION
function cluster.call(node, address, ...) 中的address必须是服务的句柄，但很多时候跨服调用并不知道句柄，需要cluster.query去查询，可以增加通过在cluster中注册的名字call，把查询工作放在远端进行。