### PR TITLE
change socket.write to socketdriver.send

### DIFF
--- a/lualib/skynet/remotedebug.lua
+++ b/lualib/skynet/remotedebug.lua
@@ -1,6 +1,6 @@
 local skynet = require "skynet"
 local debugchannel = require "debugchannel"
-local socket = require "socket"
+local socketdriver = require "socketdriver"
 local injectrun = require "skynet.injectcode"
 local table = table
 local debug = debug
@@ -56,7 +56,7 @@ local function gen_print(fd)
 			tmp[i] = tostring(tmp[i])
 		end
 		table.insert(tmp, "\n")
-		socket.write(fd, table.concat(tmp, "\t"))
+		socketdriver.send(fd, table.concat(tmp, "\t"))
 	end
 end
 
@@ -208,7 +208,7 @@ local function hook_dispatch(dispatcher, resp, fd, channel)
 	local function debug_hook()
 		while true do
 			if newline then
-				socket.write(fd, prompt)
+				socketdriver.send(fd, prompt)
 				newline = false
 			end
 			local cmd = channel:read()


### PR DESCRIPTION
这样改过之后可以直接调试使用了gate服务的模块。
因为gate服务注册了socket类型的消息，所以不能和socket模块一块使用；而debug模块只使用到了socket模块的write函数，所以这样修改后对debug的功能并没有影响，但改过之后就可以调试gate服务了。