### PR TITLE
output error information to stderr when logger is not exist.

### DIFF
--- a/skynet-src/skynet_error.c
+++ b/skynet-src/skynet_error.c
@@ -13,17 +13,21 @@
 void 
 skynet_error(struct skynet_context * context, const char *msg, ...) {
 	static uint32_t logger = 0;
+	va_list ap;
+	
 	if (logger == 0) {
 		logger = skynet_handle_findname("logger");
 	}
 	if (logger == 0) {
+		va_start(ap,msg);
+		vfprintf(stderr, msg, ap);
+		va_end(ap);
+		fprintf(stderr, "\n");
 		return;
 	}
 
 	char tmp[LOG_MESSAGE_SIZE];
 	char *data = NULL;
-
-	va_list ap;
 
 	va_start(ap,msg);
 	int len = vsnprintf(tmp, LOG_MESSAGE_SIZE, msg, ap);


### PR DESCRIPTION
若 snlua 加载自定义 logger 时出错，没有任何可见信息。