### PR TITLE
给dbgcmd增加扩展性

### DIFF
--- a/lualib/skynet/debug.lua
+++ b/lualib/skynet/debug.lua
@@ -1,4 +1,5 @@
 local table = table
+local extern_dbgcmd = {};
 
 return function (skynet, export)
 
@@ -11,7 +12,7 @@ end
 local dbgcmd
 
 local function init_dbgcmd()
-dbgcmd = {}
+dbgcmd = extern_dbgcmd
 
 function dbgcmd.MEM()
 	local kb, bytes = collectgarbage "count"


### PR DESCRIPTION
我们项目增加了一个dbgcmd的指令，主要用于热更新，但在升级skynet版本时，需要记得合并这个差异，感觉挺挫的。

但现有的debug.lua并不利于扩展，于是呢，我想通过给debug.lua增加一个upvalue来解决这个问题。

其实也是解决的挺挫的 :)