### PR TITLE
修复snax.queryglobal在slave中请求不同service会失败的bug

### DIFF
--- a/service/service_mgr.lua
+++ b/service/service_mgr.lua
@@ -148,7 +148,7 @@ local function register_local()
 	end
 
 	function cmd.GQUERY(name, ...)
-		local global_name = "@" .. name
+		local global_name = "@" .. name .. '.' .. tostring(...)
 		return waitfor(global_name, skynet.call, "SERVICE", "lua", "QUERY", global_name, ...)
 	end
 


### PR DESCRIPTION
在master/slave 模式下，在slave上调用snax.queryglobal(name)和snax.globalservice(name, ...) ，如果调的两次name是不同的service的话，就会出现该bug