### PR TITLE
add mongo auth mechanism SCRAM-SHA-1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "3rd/openssl"]
 	path = 3rd/openssl
 	url = https://github.com/openssl/openssl.git
-[submodule "3rd/mongoc"]
-	path = 3rd/mongoc
-	url = https://github.com/mongodb/mongo-c-driver.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,9 @@
 [submodule "3rd/jemalloc"]
 	path = 3rd/jemalloc
 	url = https://github.com/jemalloc/jemalloc.git
+[submodule "3rd/openssl"]
+	path = 3rd/openssl
+	url = https://github.com/openssl/openssl.git
+[submodule "3rd/mongoc"]
+	path = 3rd/mongoc
+	url = https://github.com/mongodb/mongo-c-driver.git

--- a/Makefile
+++ b/Makefile
@@ -130,11 +130,18 @@ $(LUA_CLIB_PATH)/mysqlaux.so : lualib-src/lua-mysqlaux.c | $(LUA_CLIB_PATH)
 $(LUA_CLIB_PATH)/debugchannel.so : lualib-src/lua-debugchannel.c | $(LUA_CLIB_PATH)
 	$(CC) $(CFLAGS) $(SHARED) -Iskynet-src $^ -o $@	
 
-$(LUA_CLIB_PATH)/mongo_auth.so : lualib-src/lua-mongo_auth.c lualib-src/mongoc-b64.c | $(LUA_CLIB_PATH)
-	$(CC) $(CFLAGS) $(SHARED) -Iskynet-src $^ -o $@
+openssl_macosx:
+	cd 3rd/openssl && ./Configure darwin64-x86_64-cc no-shared && make
+	
+openssl_linux:
+	cd 3rd/openssl && ./config no-shared && make
+
+$(LUA_CLIB_PATH)/mongo_auth.so : lualib-src/lua-mongo_auth.c lualib-src/mongoc-b64.c 3rd/openssl/libcrypto.a | $(LUA_CLIB_PATH) openssl_$(PLAT)
+	$(CC) $(CFLAGS) $(SHARED) -Iskynet-src $^ -o $@ -I3rd/openssl/include
 
 clean :
 	rm -f $(SKYNET_BUILD_PATH)/skynet $(CSERVICE_PATH)/*.so $(LUA_CLIB_PATH)/*.so
+	cd 3rd/openssl && $(MAKE) clean
 
 cleanall: clean
 ifneq (,$(wildcard 3rd/jemalloc/Makefile))

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ CSERVICE = snlua logger gate harbor
 LUA_CLIB = skynet socketdriver bson mongo md5 netpack \
   clientsocket memory profile multicast \
   cluster crypt sharedata stm sproto lpeg \
-  mysqlaux debugchannel
+  mysqlaux debugchannel mongo_auth
 
 SKYNET_SRC = skynet_main.c skynet_handle.c skynet_module.c skynet_mq.c \
   skynet_server.c skynet_start.c skynet_timer.c skynet_error.c \
@@ -129,6 +129,9 @@ $(LUA_CLIB_PATH)/mysqlaux.so : lualib-src/lua-mysqlaux.c | $(LUA_CLIB_PATH)
 
 $(LUA_CLIB_PATH)/debugchannel.so : lualib-src/lua-debugchannel.c | $(LUA_CLIB_PATH)
 	$(CC) $(CFLAGS) $(SHARED) -Iskynet-src $^ -o $@	
+
+$(LUA_CLIB_PATH)/mongo_auth.so : lualib-src/lua-mongo_auth.c lualib-src/mongoc-b64.c | $(LUA_CLIB_PATH)
+	$(CC) $(CFLAGS) $(SHARED) -Iskynet-src $^ -o $@
 
 clean :
 	rm -f $(SKYNET_BUILD_PATH)/skynet $(CSERVICE_PATH)/*.so $(LUA_CLIB_PATH)/*.so

--- a/Makefile
+++ b/Makefile
@@ -134,14 +134,15 @@ openssl_macosx:
 	cd 3rd/openssl && ./Configure darwin64-x86_64-cc no-shared && make
 	
 openssl_linux:
-	cd 3rd/openssl && ./config no-shared && make
+	echo $(PLAT)
+	cd 3rd/openssl && ./config no-shared no-asm && make
 
-$(LUA_CLIB_PATH)/mongo_auth.so : lualib-src/lua-mongo_auth.c lualib-src/mongoc-b64.c 3rd/openssl/libcrypto.a | $(LUA_CLIB_PATH) openssl_$(PLAT)
-	$(CC) $(CFLAGS) $(SHARED) -Iskynet-src $^ -o $@ -I3rd/openssl/include
+$(LUA_CLIB_PATH)/mongo_auth.so : lualib-src/lua-mongo_auth.c lualib-src/mongoc-b64.c | $(LUA_CLIB_PATH) openssl_$(PLAT)
+	$(CC) $(CFLAGS) $(SHARED) -Iskynet-src $^ 3rd/openssl/libcrypto.a -o $@ -I3rd/openssl/include
 
 clean :
 	rm -f $(SKYNET_BUILD_PATH)/skynet $(CSERVICE_PATH)/*.so $(LUA_CLIB_PATH)/*.so
-	cd 3rd/openssl && $(MAKE) clean
+	$(MAKE) clean -C 3rd/openssl/
 
 cleanall: clean
 ifneq (,$(wildcard 3rd/jemalloc/Makefile))

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,9 @@ openssl_macosx:
 	cd 3rd/openssl && ./Configure darwin64-x86_64-cc no-shared && make
 	
 openssl_linux:
-	echo $(PLAT)
+	cd 3rd/openssl && ./config no-shared no-asm && make
+
+openssl_freebsd:
 	cd 3rd/openssl && ./config no-shared no-asm && make
 
 $(LUA_CLIB_PATH)/mongo_auth.so : lualib-src/lua-mongo_auth.c lualib-src/mongoc-b64.c | $(LUA_CLIB_PATH) openssl_$(PLAT)

--- a/config.mongo
+++ b/config.mongo
@@ -1,0 +1,12 @@
+root = "./test/"
+default_lua_path = "./lualib/?.lua;./lualib/?/init.lua"
+thread = 1
+logger = nil
+harbor = 0
+start = "testmongoa"
+bootstrap = "snlua bootstrap"	-- The service for bootstrap
+luaservice = "./service/?.lua;".. root .."?.lua;"
+lualoader = "lualib/loader.lua"
+lua_path = root .. "/?.lua;" .. root .. "?.lua;" ..  default_lua_path
+cpath = "./cservice/?.so"
+

--- a/lualib-src/lua-mongo_auth.c
+++ b/lualib-src/lua-mongo_auth.c
@@ -1,0 +1,551 @@
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <stdint.h>
+#include <ctype.h>
+#include <string.h>
+
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+
+#define Assert(...)
+
+static const char Base64[] =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static const char Pad64 = '=';
+
+static int mongoc_b64rmap_initialized = 0;
+static unsigned char mongoc_b64rmap[256];
+
+static const unsigned char mongoc_b64rmap_special = 0xf0;
+static const unsigned char mongoc_b64rmap_end = 0xfd;
+static const unsigned char mongoc_b64rmap_space = 0xfe;
+static const unsigned char mongoc_b64rmap_invalid = 0xff;
+
+/**
+ * Initializing the reverse map is not thread safe.
+ * Which is fine for NSD. For now...
+ **/
+void
+mongoc_b64_initialize_rmap (void)
+{
+	int i;
+	unsigned char ch;
+
+	/* Null: end of string, stop parsing */
+	mongoc_b64rmap[0] = mongoc_b64rmap_end;
+
+	for (i = 1; i < 256; ++i) {
+		ch = (unsigned char)i;
+		/* Whitespaces */
+		if (isspace(ch))
+			mongoc_b64rmap[i] = mongoc_b64rmap_space;
+		/* Padding: stop parsing */
+		else if (ch == Pad64)
+			mongoc_b64rmap[i] = mongoc_b64rmap_end;
+		/* Non-base64 char */
+		else
+			mongoc_b64rmap[i] = mongoc_b64rmap_invalid;
+	}
+
+	/* Fill reverse mapping for base64 chars */
+	for (i = 0; Base64[i] != '\0'; ++i)
+		mongoc_b64rmap[(unsigned char)Base64[i]] = i;
+
+	mongoc_b64rmap_initialized = 1;
+}
+
+static int
+mongoc_b64_pton_do(char const *src, unsigned char *target, size_t targsize)
+{
+	int tarindex, state, ch;
+	unsigned char ofs;
+
+	state = 0;
+	tarindex = 0;
+
+	while (1)
+	{
+		ch = *src++;
+		ofs = mongoc_b64rmap[ch];
+
+		if (ofs >= mongoc_b64rmap_special) {
+			/* Ignore whitespaces */
+			if (ofs == mongoc_b64rmap_space)
+				continue;
+			/* End of base64 characters */
+			if (ofs == mongoc_b64rmap_end)
+				break;
+			/* A non-base64 character. */
+			return (-1);
+		}
+
+		switch (state) {
+		case 0:
+			if ((size_t)tarindex >= targsize)
+				return (-1);
+			target[tarindex] = ofs << 2;
+			state = 1;
+			break;
+		case 1:
+			if ((size_t)tarindex + 1 >= targsize)
+				return (-1);
+			target[tarindex]   |=  ofs >> 4;
+			target[tarindex+1]  = (ofs & 0x0f)
+						<< 4 ;
+			tarindex++;
+			state = 2;
+			break;
+		case 2:
+			if ((size_t)tarindex + 1 >= targsize)
+				return (-1);
+			target[tarindex]   |=  ofs >> 2;
+			target[tarindex+1]  = (ofs & 0x03)
+						<< 6;
+			tarindex++;
+			state = 3;
+			break;
+		case 3:
+			if ((size_t)tarindex >= targsize)
+				return (-1);
+			target[tarindex] |= ofs;
+			tarindex++;
+			state = 0;
+			break;
+		default:
+			abort();
+		}
+	}
+
+	/*
+	 * We are done decoding Base-64 chars.  Let's see if we ended
+	 * on a byte boundary, and/or with erroneous trailing characters.
+	 */
+
+	if (ch == Pad64) {		/* We got a pad char. */
+		ch = *src++;		/* Skip it, get next. */
+		switch (state) {
+		case 0:		/* Invalid = in first position */
+		case 1:		/* Invalid = in second position */
+			return (-1);
+
+		case 2:		/* Valid, means one byte of info */
+			/* Skip any number of spaces. */
+			for ((void)NULL; ch != '\0'; ch = *src++)
+				if (mongoc_b64rmap[ch] != mongoc_b64rmap_space)
+					break;
+			/* Make sure there is another trailing = sign. */
+			if (ch != Pad64)
+				return (-1);
+			ch = *src++;		/* Skip the = */
+			/* Fall through to "single trailing =" case. */
+			/* FALLTHROUGH */
+
+		case 3:		/* Valid, means two bytes of info */
+			/*
+			 * We know this char is an =.  Is there anything but
+			 * whitespace after it?
+			 */
+			for ((void)NULL; ch != '\0'; ch = *src++)
+				if (mongoc_b64rmap[ch] != mongoc_b64rmap_space)
+					return (-1);
+
+			/*
+			 * Now make sure for cases 2 and 3 that the "extra"
+			 * bits that slopped past the last full byte were
+			 * zeros.  If we don't check them, they become a
+			 * subliminal channel.
+			 */
+			if (target[tarindex] != 0)
+				return (-1);
+		default:
+			break;
+		}
+	} else {
+		/*
+		 * We ended by seeing the end of the string.  Make sure we
+		 * have no partial bytes lying around.
+		 */
+		if (state != 0)
+			return (-1);
+	}
+
+	return (tarindex);
+}
+
+
+static int
+mongoc_b64_pton_len(char const *src)
+{
+	int tarindex, state, ch;
+	unsigned char ofs;
+
+	state = 0;
+	tarindex = 0;
+
+	while (1)
+	{
+		ch = *src++;
+		ofs = mongoc_b64rmap[ch];
+
+		if (ofs >= mongoc_b64rmap_special) {
+			/* Ignore whitespaces */
+			if (ofs == mongoc_b64rmap_space)
+				continue;
+			/* End of base64 characters */
+			if (ofs == mongoc_b64rmap_end)
+				break;
+			/* A non-base64 character. */
+			return (-1);
+		}
+
+		switch (state) {
+		case 0:
+			state = 1;
+			break;
+		case 1:
+			tarindex++;
+			state = 2;
+			break;
+		case 2:
+			tarindex++;
+			state = 3;
+			break;
+		case 3:
+			tarindex++;
+			state = 0;
+			break;
+		default:
+			abort();
+		}
+	}
+
+	/*
+	 * We are done decoding Base-64 chars.  Let's see if we ended
+	 * on a byte boundary, and/or with erroneous trailing characters.
+	 */
+
+	if (ch == Pad64) {		/* We got a pad char. */
+		ch = *src++;		/* Skip it, get next. */
+		switch (state) {
+		case 0:		/* Invalid = in first position */
+		case 1:		/* Invalid = in second position */
+			return (-1);
+
+		case 2:		/* Valid, means one byte of info */
+			/* Skip any number of spaces. */
+			for ((void)NULL; ch != '\0'; ch = *src++)
+				if (mongoc_b64rmap[ch] != mongoc_b64rmap_space)
+					break;
+			/* Make sure there is another trailing = sign. */
+			if (ch != Pad64)
+				return (-1);
+			ch = *src++;		/* Skip the = */
+			/* Fall through to "single trailing =" case. */
+			/* FALLTHROUGH */
+
+		case 3:		/* Valid, means two bytes of info */
+			/*
+			 * We know this char is an =.  Is there anything but
+			 * whitespace after it?
+			 */
+			for ((void)NULL; ch != '\0'; ch = *src++)
+				if (mongoc_b64rmap[ch] != mongoc_b64rmap_space)
+					return (-1);
+
+		default:
+			break;
+		}
+	} else {
+		/*
+		 * We ended by seeing the end of the string.  Make sure we
+		 * have no partial bytes lying around.
+		 */
+		if (state != 0)
+			return (-1);
+	}
+
+	return (tarindex);
+}
+
+int
+mongoc_b64_pton(char const *src, unsigned char *target, size_t targsize)
+{
+	if (!mongoc_b64rmap_initialized)
+		mongoc_b64_initialize_rmap ();
+
+	if (target)
+		return mongoc_b64_pton_do (src, target, targsize);
+	else
+		return mongoc_b64_pton_len (src);
+}
+
+int Base64encode_len(int len)
+{
+	return ((len + 2) / 3 * 4) + 4;
+}
+
+int Base64encode(char *target, int targsize, const char *src, int srclength)
+{
+   int datalength = 0;
+   unsigned char input[3];
+   unsigned char output[4];
+   int i;
+
+   while (2 < srclength) {
+	  input[0] = *src++;
+	  input[1] = *src++;
+	  input[2] = *src++;
+	  srclength -= 3;
+
+	  output[0] = input[0] >> 2;
+	  output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
+	  output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+	  output[3] = input[2] & 0x3f;
+	  Assert (output[0] < 64);
+	  Assert (output[1] < 64);
+	  Assert (output[2] < 64);
+	  Assert (output[3] < 64);
+
+	  if (datalength + 4 > targsize) {
+		 return -1;
+	  }
+	  target[datalength++] = Base64[output[0]];
+	  target[datalength++] = Base64[output[1]];
+	  target[datalength++] = Base64[output[2]];
+	  target[datalength++] = Base64[output[3]];
+   }
+
+   /* Now we worry about padding. */
+   if (0 != srclength) {
+	  /* Get what's left. */
+	  input[0] = input[1] = input[2] = '\0';
+
+	  for (i = 0; i < srclength; i++) {
+		 input[i] = *src++;
+	  }
+	  output[0] = input[0] >> 2;
+	  output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
+	  output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+	  Assert (output[0] < 64);
+	  Assert (output[1] < 64);
+	  Assert (output[2] < 64);
+
+	  if (datalength + 4 > targsize) {
+		 return -1;
+	  }
+	  target[datalength++] = Base64[output[0]];
+	  target[datalength++] = Base64[output[1]];
+
+	  if (srclength == 1) {
+		 target[datalength++] = Pad64;
+	  } else{
+		 target[datalength++] = Base64[output[2]];
+	  }
+	  target[datalength++] = Pad64;
+   }
+
+   if (datalength >= targsize) {
+	  return -1;
+   }
+   target[datalength] = '\0'; /* Returned value doesn't count \0. */
+   return (int)datalength;
+}
+
+static int
+encode_base64(lua_State *L){
+	size_t len, olen;
+	const char * str;
+	char *ostr;
+	str = luaL_checklstring(L, 1, &len);
+	olen = Base64encode_len(len);
+	ostr = lua_newuserdata(L, olen);
+	olen = Base64encode(ostr, olen, str, len);
+	
+	lua_pushlstring(L, ostr, olen);
+	
+	return 1;
+}
+
+static int
+decode_base64(lua_State *L){
+	int olen;
+	const char * str;
+	char *ostr;
+	str = luaL_checkstring(L, 1);
+	olen = 1024;
+	ostr = lua_newuserdata(L, olen);
+	olen = mongoc_b64_pton(str, (unsigned char*)ostr, olen);
+	if (olen <= 0) {
+		return 0;
+	}
+	lua_pushlstring(L, ostr, olen);
+	
+	return 1;
+}
+
+static int
+hmac_sha1(lua_State *L) {
+	u_char				  *sec, *sts;
+	size_t				   lsec, lsts;
+	unsigned int			 md_len;
+	unsigned char			md[EVP_MAX_MD_SIZE];
+	const EVP_MD			*evp_md;
+
+	if (lua_gettop(L) != 2) {
+		return luaL_error(L, "expecting 2 arguments, but got %d",
+						  lua_gettop(L));
+	}
+
+	sec = (u_char *) luaL_checklstring(L, 1, &lsec);
+	sts = (u_char *) luaL_checklstring(L, 2, &lsts);
+
+	evp_md = EVP_sha1();
+
+	HMAC(evp_md, sec, lsec, sts, lsts, md, &md_len);
+
+	lua_pushlstring(L, (char *) md, md_len);
+
+	return 1;
+}
+
+static int
+xor_str(lua_State *L) {
+	siz_t la, lb;
+	int i;
+	const unsigned char *a, *b;
+	unsigned char * output;
+	a = (const unsigned char*)luaL_checklstring(L, 1, &la);
+	b = (const unsigned char*)luaL_checklstring(L, 2, &lb);
+	if (la != 20 || lb != 20) {
+		return 0;
+	}
+	output = lua_newuserdata(L, 20);
+	for (i=0; i<20; i++) {
+		output[i] = a[i] ^ b[i];
+	}
+	
+	lua_pushlstring(L, output, 20);
+	
+	return 1;
+}
+#define MONGOC_SCRAM_HASH_SIZE 20
+static int
+sha1_bin(lua_State *L)
+{
+	EVP_MD_CTX * digest_ctx;
+	int rval = 0;
+	size_t len;
+	const char * str;
+	unsigned char output[20];
+	str = luaL_checklstring(L, 1, &len);
+
+	digest_ctx = EVP_MD_CTX_new();
+	EVP_MD_CTX_init (digest_ctx);
+
+	if (1 != EVP_DigestInit_ex (digest_ctx, EVP_sha1 (), NULL)) {
+		goto cleanup;
+	}
+	
+	if (1 != EVP_DigestUpdate (digest_ctx, str, len)) {
+		goto cleanup;
+	}
+	
+	if (EVP_DigestFinal_ex (digest_ctx, output, NULL) == 1) {
+		lua_pushlstring(L, (const char*)output, 20);
+		rval = 1;
+	}
+	
+cleanup:
+	EVP_MD_CTX_free(digest_ctx);
+	
+	return rval;
+}
+
+static void
+_mongoc_scram_salt_password (unsigned char       *output,
+							 const char          *password,
+							 size_t               password_len,
+							 const unsigned char *salt,
+							 size_t               salt_len,
+							 int                  iterations)
+{
+   unsigned char intermediate_digest[MONGOC_SCRAM_HASH_SIZE];
+   unsigned char start_key[MONGOC_SCRAM_HASH_SIZE];
+
+   /* Placeholder for HMAC return size, will always be scram::hashSize for HMAC SHA-1 */
+   uint32_t hash_len = 0;
+   int i;
+   int k;
+
+   memcpy (start_key, salt, salt_len);
+
+   start_key[salt_len] = 0;
+   start_key[salt_len + 1] = 0;
+   start_key[salt_len + 2] = 0;
+   start_key[salt_len + 3] = 1;
+
+   /* U1 = HMAC(input, salt + 0001) */
+   HMAC (EVP_sha1 (),
+		 password,
+		 password_len,
+		 start_key,
+		 sizeof (start_key),
+		 output,
+		 &hash_len);
+
+   memcpy (intermediate_digest, output, MONGOC_SCRAM_HASH_SIZE);
+
+   /* intermediateDigest contains Ui and output contains the accumulated XOR:ed result */
+   for (i = 2; i <= iterations; i++) {
+	  HMAC (EVP_sha1 (),
+			password,
+			password_len,
+			intermediate_digest,
+			sizeof (intermediate_digest),
+			intermediate_digest,
+			&hash_len);
+
+	  for (k = 0; k < MONGOC_SCRAM_HASH_SIZE; k++) {
+		 output[k] ^= intermediate_digest[k];
+	  }
+   }
+}
+
+static int
+salt_password(lua_State *L) {
+	size_t lp, ls;
+	const char * password, *salt;
+	unsigned int iterations;
+	unsigned char * output = lua_newuserdata(L, 20);
+	password = luaL_checklstring(L, 1, &lp);
+	salt = luaL_checklstring(L, 2, &ls);
+	iterations = luaL_checkinteger(L, 3);
+	
+	_mongoc_scram_salt_password(output, password, lp, (const unsigned char*)salt, ls, iterations);
+	
+	lua_pushlstring(L, (char*)output, 20);
+	return 1;
+}
+
+int
+luaopen_mongo_auth(lua_State *L) {
+	luaL_checkversion(L);
+	
+	luaL_Reg l[] = {
+		{ "encode_base64", encode_base64 },
+		{ "decode_base64", decode_base64 },
+		{ "hmac_sha1", hmac_sha1 },
+		{ "xor_str", xor_str },
+		{ "sha1_bin", sha1_bin },
+		{ "salt_password", salt_password },
+		{ NULL, NULL},
+	};
+	
+	luaL_newlib(L, l);
+	return 1;
+}

--- a/lualib-src/lua-mongo_auth.c
+++ b/lualib-src/lua-mongo_auth.c
@@ -12,507 +12,154 @@
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 
-#define Assert(...)
-
-static const char Base64[] =
-	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-static const char Pad64 = '=';
-
-static int mongoc_b64rmap_initialized = 0;
-static unsigned char mongoc_b64rmap[256];
-
-static const unsigned char mongoc_b64rmap_special = 0xf0;
-static const unsigned char mongoc_b64rmap_end = 0xfd;
-static const unsigned char mongoc_b64rmap_space = 0xfe;
-static const unsigned char mongoc_b64rmap_invalid = 0xff;
-
-/**
- * Initializing the reverse map is not thread safe.
- * Which is fine for NSD. For now...
- **/
-void
-mongoc_b64_initialize_rmap (void)
-{
-	int i;
-	unsigned char ch;
-
-	/* Null: end of string, stop parsing */
-	mongoc_b64rmap[0] = mongoc_b64rmap_end;
-
-	for (i = 1; i < 256; ++i) {
-		ch = (unsigned char)i;
-		/* Whitespaces */
-		if (isspace(ch))
-			mongoc_b64rmap[i] = mongoc_b64rmap_space;
-		/* Padding: stop parsing */
-		else if (ch == Pad64)
-			mongoc_b64rmap[i] = mongoc_b64rmap_end;
-		/* Non-base64 char */
-		else
-			mongoc_b64rmap[i] = mongoc_b64rmap_invalid;
-	}
-
-	/* Fill reverse mapping for base64 chars */
-	for (i = 0; Base64[i] != '\0'; ++i)
-		mongoc_b64rmap[(unsigned char)Base64[i]] = i;
-
-	mongoc_b64rmap_initialized = 1;
-}
+#include "mongoc-b64-private.h"
+#define MONGOC_SCRAM_HASH_SIZE 20
 
 static int
-mongoc_b64_pton_do(char const *src, unsigned char *target, size_t targsize)
-{
-	int tarindex, state, ch;
-	unsigned char ofs;
-
-	state = 0;
-	tarindex = 0;
-
-	while (1)
-	{
-		ch = *src++;
-		ofs = mongoc_b64rmap[ch];
-
-		if (ofs >= mongoc_b64rmap_special) {
-			/* Ignore whitespaces */
-			if (ofs == mongoc_b64rmap_space)
-				continue;
-			/* End of base64 characters */
-			if (ofs == mongoc_b64rmap_end)
-				break;
-			/* A non-base64 character. */
-			return (-1);
-		}
-
-		switch (state) {
-		case 0:
-			if ((size_t)tarindex >= targsize)
-				return (-1);
-			target[tarindex] = ofs << 2;
-			state = 1;
-			break;
-		case 1:
-			if ((size_t)tarindex + 1 >= targsize)
-				return (-1);
-			target[tarindex]   |=  ofs >> 4;
-			target[tarindex+1]  = (ofs & 0x0f)
-						<< 4 ;
-			tarindex++;
-			state = 2;
-			break;
-		case 2:
-			if ((size_t)tarindex + 1 >= targsize)
-				return (-1);
-			target[tarindex]   |=  ofs >> 2;
-			target[tarindex+1]  = (ofs & 0x03)
-						<< 6;
-			tarindex++;
-			state = 3;
-			break;
-		case 3:
-			if ((size_t)tarindex >= targsize)
-				return (-1);
-			target[tarindex] |= ofs;
-			tarindex++;
-			state = 0;
-			break;
-		default:
-			abort();
-		}
-	}
-
-	/*
-	 * We are done decoding Base-64 chars.  Let's see if we ended
-	 * on a byte boundary, and/or with erroneous trailing characters.
-	 */
-
-	if (ch == Pad64) {		/* We got a pad char. */
-		ch = *src++;		/* Skip it, get next. */
-		switch (state) {
-		case 0:		/* Invalid = in first position */
-		case 1:		/* Invalid = in second position */
-			return (-1);
-
-		case 2:		/* Valid, means one byte of info */
-			/* Skip any number of spaces. */
-			for ((void)NULL; ch != '\0'; ch = *src++)
-				if (mongoc_b64rmap[ch] != mongoc_b64rmap_space)
-					break;
-			/* Make sure there is another trailing = sign. */
-			if (ch != Pad64)
-				return (-1);
-			ch = *src++;		/* Skip the = */
-			/* Fall through to "single trailing =" case. */
-			/* FALLTHROUGH */
-
-		case 3:		/* Valid, means two bytes of info */
-			/*
-			 * We know this char is an =.  Is there anything but
-			 * whitespace after it?
-			 */
-			for ((void)NULL; ch != '\0'; ch = *src++)
-				if (mongoc_b64rmap[ch] != mongoc_b64rmap_space)
-					return (-1);
-
-			/*
-			 * Now make sure for cases 2 and 3 that the "extra"
-			 * bits that slopped past the last full byte were
-			 * zeros.  If we don't check them, they become a
-			 * subliminal channel.
-			 */
-			if (target[tarindex] != 0)
-				return (-1);
-		default:
-			break;
-		}
-	} else {
-		/*
-		 * We ended by seeing the end of the string.  Make sure we
-		 * have no partial bytes lying around.
-		 */
-		if (state != 0)
-			return (-1);
-	}
-
-	return (tarindex);
-}
-
-
-static int
-mongoc_b64_pton_len(char const *src)
-{
-	int tarindex, state, ch;
-	unsigned char ofs;
-
-	state = 0;
-	tarindex = 0;
-
-	while (1)
-	{
-		ch = *src++;
-		ofs = mongoc_b64rmap[ch];
-
-		if (ofs >= mongoc_b64rmap_special) {
-			/* Ignore whitespaces */
-			if (ofs == mongoc_b64rmap_space)
-				continue;
-			/* End of base64 characters */
-			if (ofs == mongoc_b64rmap_end)
-				break;
-			/* A non-base64 character. */
-			return (-1);
-		}
-
-		switch (state) {
-		case 0:
-			state = 1;
-			break;
-		case 1:
-			tarindex++;
-			state = 2;
-			break;
-		case 2:
-			tarindex++;
-			state = 3;
-			break;
-		case 3:
-			tarindex++;
-			state = 0;
-			break;
-		default:
-			abort();
-		}
-	}
-
-	/*
-	 * We are done decoding Base-64 chars.  Let's see if we ended
-	 * on a byte boundary, and/or with erroneous trailing characters.
-	 */
-
-	if (ch == Pad64) {		/* We got a pad char. */
-		ch = *src++;		/* Skip it, get next. */
-		switch (state) {
-		case 0:		/* Invalid = in first position */
-		case 1:		/* Invalid = in second position */
-			return (-1);
-
-		case 2:		/* Valid, means one byte of info */
-			/* Skip any number of spaces. */
-			for ((void)NULL; ch != '\0'; ch = *src++)
-				if (mongoc_b64rmap[ch] != mongoc_b64rmap_space)
-					break;
-			/* Make sure there is another trailing = sign. */
-			if (ch != Pad64)
-				return (-1);
-			ch = *src++;		/* Skip the = */
-			/* Fall through to "single trailing =" case. */
-			/* FALLTHROUGH */
-
-		case 3:		/* Valid, means two bytes of info */
-			/*
-			 * We know this char is an =.  Is there anything but
-			 * whitespace after it?
-			 */
-			for ((void)NULL; ch != '\0'; ch = *src++)
-				if (mongoc_b64rmap[ch] != mongoc_b64rmap_space)
-					return (-1);
-
-		default:
-			break;
-		}
-	} else {
-		/*
-		 * We ended by seeing the end of the string.  Make sure we
-		 * have no partial bytes lying around.
-		 */
-		if (state != 0)
-			return (-1);
-	}
-
-	return (tarindex);
-}
-
-int
-mongoc_b64_pton(char const *src, unsigned char *target, size_t targsize)
-{
-	if (!mongoc_b64rmap_initialized)
-		mongoc_b64_initialize_rmap ();
-
-	if (target)
-		return mongoc_b64_pton_do (src, target, targsize);
-	else
-		return mongoc_b64_pton_len (src);
-}
-
-int Base64encode_len(int len)
-{
-	return ((len + 2) / 3 * 4) + 4;
-}
-
-int Base64encode(char *target, int targsize, const char *src, int srclength)
-{
-   int datalength = 0;
-   unsigned char input[3];
-   unsigned char output[4];
-   int i;
-
-   while (2 < srclength) {
-	  input[0] = *src++;
-	  input[1] = *src++;
-	  input[2] = *src++;
-	  srclength -= 3;
-
-	  output[0] = input[0] >> 2;
-	  output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
-	  output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
-	  output[3] = input[2] & 0x3f;
-	  Assert (output[0] < 64);
-	  Assert (output[1] < 64);
-	  Assert (output[2] < 64);
-	  Assert (output[3] < 64);
-
-	  if (datalength + 4 > targsize) {
-		 return -1;
-	  }
-	  target[datalength++] = Base64[output[0]];
-	  target[datalength++] = Base64[output[1]];
-	  target[datalength++] = Base64[output[2]];
-	  target[datalength++] = Base64[output[3]];
-   }
-
-   /* Now we worry about padding. */
-   if (0 != srclength) {
-	  /* Get what's left. */
-	  input[0] = input[1] = input[2] = '\0';
-
-	  for (i = 0; i < srclength; i++) {
-		 input[i] = *src++;
-	  }
-	  output[0] = input[0] >> 2;
-	  output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
-	  output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
-	  Assert (output[0] < 64);
-	  Assert (output[1] < 64);
-	  Assert (output[2] < 64);
-
-	  if (datalength + 4 > targsize) {
-		 return -1;
-	  }
-	  target[datalength++] = Base64[output[0]];
-	  target[datalength++] = Base64[output[1]];
-
-	  if (srclength == 1) {
-		 target[datalength++] = Pad64;
-	  } else{
-		 target[datalength++] = Base64[output[2]];
-	  }
-	  target[datalength++] = Pad64;
-   }
-
-   if (datalength >= targsize) {
-	  return -1;
-   }
-   target[datalength] = '\0'; /* Returned value doesn't count \0. */
-   return (int)datalength;
-}
-
-static int
-encode_base64(lua_State *L){
-	size_t len, olen;
-	const char * str;
-	char *ostr;
-	str = luaL_checklstring(L, 1, &len);
-	olen = Base64encode_len(len);
-	ostr = lua_newuserdata(L, olen);
-	olen = Base64encode(ostr, olen, str, len);
+encode_base64(lua_State *L) {
+	size_t len;
+	const char * src = luaL_checklstring(L, 1, &len);
+	char * output = lua_newuserdata(L, len*2);
 	
-	lua_pushlstring(L, ostr, olen);
+	len = mongoc_b64_ntop((uint8_t*)src, len, (uint8_t*)output, len*2);
+	
+	lua_pushstring(L, output);
 	
 	return 1;
 }
 
 static int
-decode_base64(lua_State *L){
-	int olen;
-	const char * str;
-	char *ostr;
-	str = luaL_checkstring(L, 1);
-	olen = 1024;
-	ostr = lua_newuserdata(L, olen);
-	olen = mongoc_b64_pton(str, (unsigned char*)ostr, olen);
-	if (olen <= 0) {
+decode_base64(lua_State *L) {
+	const char * src = luaL_checkstring(L, 1);
+	size_t len = strlen(src);
+	char * output = lua_newuserdata(L, len);
+	
+	len = mongoc_b64_pton(src, (uint8_t*)output, len);
+	
+	if (len <= 0) {
 		return 0;
 	}
-	lua_pushlstring(L, ostr, olen);
+	
+	lua_pushlstring(L, output, len);
+	
+	return 1;
+}
+
+static int
+xor_str(lua_State *L) {
+	size_t la, lb;
+	int i;
+	const unsigned char *a, *b;
+	unsigned char * output;
+	a = (const unsigned char*)luaL_checklstring(L, 1, &la);
+	b = (const unsigned char*)luaL_checklstring(L, 2, &lb);
+	if (la != lb) {
+		return 0;
+	}
+	output = lua_newuserdata(L, la);
+	for (i=0; i<la; i++) {
+		output[i] = a[i] ^ b[i];
+	}
+	
+	lua_pushlstring(L, output, la);
 	
 	return 1;
 }
 
 static int
 hmac_sha1(lua_State *L) {
-	u_char				  *sec, *sts;
-	size_t				   lsec, lsts;
-	unsigned int			 md_len;
-	unsigned char			md[EVP_MAX_MD_SIZE];
-	const EVP_MD			*evp_md;
-
+	const char    *sec, *sts;
+	size_t        lsec, lsts;
+	size_t        md_len;
+	u_char        md[EVP_MAX_MD_SIZE];
+	
 	if (lua_gettop(L) != 2) {
-		return luaL_error(L, "expecting 2 arguments, but got %d",
-						  lua_gettop(L));
+		return luaL_error(L, "expecting 2 arguments, but got %d",lua_gettop(L));
 	}
-
-	sec = (u_char *) luaL_checklstring(L, 1, &lsec);
-	sts = (u_char *) luaL_checklstring(L, 2, &lsts);
-
-	evp_md = EVP_sha1();
-
-	HMAC(evp_md, sec, lsec, sts, lsts, md, &md_len);
-
-	lua_pushlstring(L, (char *) md, md_len);
-
+	
+	sec = luaL_checklstring(L, 1, &lsec);
+	sts = luaL_checklstring(L, 2, &lsts);
+	
+	HMAC(EVP_sha1(), (u_char*)sec, lsec, (u_char*)sts, lsts, md, &md_len);
+	
+	lua_pushlstring(L, (char*)md, md_len);
+	
 	return 1;
 }
 
 static int
-xor_str(lua_State *L) {
-	siz_t la, lb;
-	int i;
-	const unsigned char *a, *b;
-	unsigned char * output;
-	a = (const unsigned char*)luaL_checklstring(L, 1, &la);
-	b = (const unsigned char*)luaL_checklstring(L, 2, &lb);
-	if (la != 20 || lb != 20) {
-		return 0;
-	}
-	output = lua_newuserdata(L, 20);
-	for (i=0; i<20; i++) {
-		output[i] = a[i] ^ b[i];
-	}
-	
-	lua_pushlstring(L, output, 20);
-	
-	return 1;
-}
-#define MONGOC_SCRAM_HASH_SIZE 20
-static int
-sha1_bin(lua_State *L)
-{
+sha1_bin(lua_State *L) {
 	EVP_MD_CTX * digest_ctx;
 	int rval = 0;
 	size_t len;
 	const char * str;
 	unsigned char output[20];
 	str = luaL_checklstring(L, 1, &len);
-
+	
 	digest_ctx = EVP_MD_CTX_new();
+	
 	EVP_MD_CTX_init (digest_ctx);
-
-	if (1 != EVP_DigestInit_ex (digest_ctx, EVP_sha1 (), NULL)) {
-		goto cleanup;
-	}
 	
-	if (1 != EVP_DigestUpdate (digest_ctx, str, len)) {
-		goto cleanup;
+	for (;;) {
+		if (1 != EVP_DigestInit_ex (digest_ctx, EVP_sha1 (), NULL)) {
+			break;
+		}
+		
+		if (1 != EVP_DigestUpdate (digest_ctx, str, len)) {
+			break;
+		}
+		
+		if (EVP_DigestFinal_ex (digest_ctx, output, NULL) == 1) {
+			lua_pushlstring(L, (const char*)output, 20);
+			rval = 1;
+		}
+		break;
 	}
-	
-	if (EVP_DigestFinal_ex (digest_ctx, output, NULL) == 1) {
-		lua_pushlstring(L, (const char*)output, 20);
-		rval = 1;
-	}
-	
-cleanup:
 	EVP_MD_CTX_free(digest_ctx);
 	
 	return rval;
 }
 
 static void
-_mongoc_scram_salt_password (unsigned char       *output,
-							 const char          *password,
-							 size_t               password_len,
-							 const unsigned char *salt,
-							 size_t               salt_len,
-							 int                  iterations)
-{
-   unsigned char intermediate_digest[MONGOC_SCRAM_HASH_SIZE];
-   unsigned char start_key[MONGOC_SCRAM_HASH_SIZE];
-
-   /* Placeholder for HMAC return size, will always be scram::hashSize for HMAC SHA-1 */
-   uint32_t hash_len = 0;
-   int i;
-   int k;
-
-   memcpy (start_key, salt, salt_len);
-
-   start_key[salt_len] = 0;
-   start_key[salt_len + 1] = 0;
-   start_key[salt_len + 2] = 0;
-   start_key[salt_len + 3] = 1;
-
-   /* U1 = HMAC(input, salt + 0001) */
-   HMAC (EVP_sha1 (),
-		 password,
-		 password_len,
-		 start_key,
-		 sizeof (start_key),
-		 output,
-		 &hash_len);
-
-   memcpy (intermediate_digest, output, MONGOC_SCRAM_HASH_SIZE);
-
-   /* intermediateDigest contains Ui and output contains the accumulated XOR:ed result */
-   for (i = 2; i <= iterations; i++) {
-	  HMAC (EVP_sha1 (),
-			password,
-			password_len,
-			intermediate_digest,
-			sizeof (intermediate_digest),
-			intermediate_digest,
+_mongoc_scram_salt_password(
+	uint8_t        *output,
+	const char     *password,
+	size_t          password_len,
+	const uint8_t  *salt,
+	size_t        salt_len,
+	int           iterations
+) {
+	uint8_t intermediate_digest[MONGOC_SCRAM_HASH_SIZE];
+	uint8_t start_key[MONGOC_SCRAM_HASH_SIZE];
+	
+	uint32_t hash_len = 0;
+	int i, k;
+	
+	memcpy (start_key, salt, salt_len);
+	
+	/* U1 = HMAC(input, salt + 0001) */
+	HMAC (EVP_sha1 (),
+		password, 
+		password_len, 
+		start_key, 
+		sizeof (start_key), 
+		output,
+		&hash_len);
+	
+	memcpy (intermediate_digest, output, MONGOC_SCRAM_HASH_SIZE);
+	
+	/* intermediateDigest contains Ui and output contains the accumulated XOR:ed result */
+	for (i = 2; i <= iterations; i++) {
+		HMAC (EVP_sha1 (), 
+			password, 
+			password_len, 
+			intermediate_digest, 
+			sizeof (intermediate_digest), 
+			intermediate_digest, 
 			&hash_len);
-
-	  for (k = 0; k < MONGOC_SCRAM_HASH_SIZE; k++) {
-		 output[k] ^= intermediate_digest[k];
-	  }
+      for (k = 0; k < MONGOC_SCRAM_HASH_SIZE; k++) {
+         output[k] ^= intermediate_digest[k];
+      }
    }
 }
 
@@ -539,8 +186,8 @@ luaopen_mongo_auth(lua_State *L) {
 	luaL_Reg l[] = {
 		{ "encode_base64", encode_base64 },
 		{ "decode_base64", decode_base64 },
-		{ "hmac_sha1", hmac_sha1 },
 		{ "xor_str", xor_str },
+		{ "hmac_sha1", hmac_sha1 },
 		{ "sha1_bin", sha1_bin },
 		{ "salt_password", salt_password },
 		{ NULL, NULL},

--- a/lualib-src/mongoc-b64-private.h
+++ b/lualib-src/mongoc-b64-private.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MONGOC_B64_PRIVATE_H
+#define MONGOC_B64_PRIVATE_H
+
+int
+mongoc_b64_ntop (uint8_t const *src,
+                 size_t         srclength,
+                 char          *target,
+                 size_t         targsize);
+
+void
+mongoc_b64_initialize_rmap (void);
+
+int
+mongoc_b64_pton (char const *src,
+                 uint8_t    *target,
+                 size_t      targsize);
+
+#endif /* MONGOC_B64_PRIVATE_H */

--- a/lualib-src/mongoc-b64.c
+++ b/lualib-src/mongoc-b64.c
@@ -1,0 +1,521 @@
+/*
+ * Copyright (c) 1996, 1998 by Internet Software Consortium.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND INTERNET SOFTWARE CONSORTIUM DISCLAIMS
+ * ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL INTERNET SOFTWARE
+ * CONSORTIUM BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+ * DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+ * PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ * ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ */
+
+/*
+ * Portions Copyright (c) 1995 by International Business Machines, Inc.
+ *
+ * International Business Machines, Inc. (hereinafter called IBM) grants
+ * permission under its copyrights to use, copy, modify, and distribute this
+ * Software with or without fee, provided that the above copyright notice and
+ * all paragraphs of this notice appear in all copies, and that the name of IBM
+ * not be used in connection with the marketing of any product incorporating
+ * the Software or modifications thereof, without specific, written prior
+ * permission.
+ *
+ * To the extent it has a right to do so, IBM grants an immunity from suit
+ * under its patents, if any, for the use, sale or manufacture of products to
+ * the extent that such products are used for performing Domain Name System
+ * dynamic updates in TCP/IP networks by means of the Software.  No immunity is
+ * granted for any product per se or for any other function of any product.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", AND IBM DISCLAIMS ALL WARRANTIES,
+ * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.  IN NO EVENT SHALL IBM BE LIABLE FOR ANY SPECIAL,
+ * DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE, EVEN
+ * IF IBM IS APPRISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ */
+
+#include <stdint.h>
+#include <string.h> // for size_t
+#include <ctype.h> // for isspace
+#include "mongoc-b64-private.h"
+
+#define Assert(Cond) if (!(Cond)) return (-1)
+
+static const char Base64[] =
+   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static const char Pad64 = '=';
+
+/* (From RFC1521 and draft-ietf-dnssec-secext-03.txt)
+ * The following encoding technique is taken from RFC 1521 by Borenstein
+ * and Freed.  It is reproduced here in a slightly edited form for
+ * convenience.
+ *
+ * A 65-character subset of US-ASCII is used, enabling 6 bits to be
+ * represented per printable character. (The extra 65th character, "=",
+ * is used to signify a special processing function.)
+ *
+ * The encoding process represents 24-bit groups of input bits as output
+ * strings of 4 encoded characters. Proceeding from left to right, a
+ * 24-bit input group is formed by concatenating 3 8-bit input groups.
+ * These 24 bits are then treated as 4 concatenated 6-bit groups, each
+ * of which is translated into a single digit in the base64 alphabet.
+ *
+ * Each 6-bit group is used as an index into an array of 64 printable
+ * characters. The character referenced by the index is placed in the
+ * output string.
+ *
+ *                       Table 1: The Base64 Alphabet
+ *
+ *    Value Encoding  Value Encoding  Value Encoding  Value Encoding
+ *        0 A            17 R            34 i            51 z
+ *        1 B            18 S            35 j            52 0
+ *        2 C            19 T            36 k            53 1
+ *        3 D            20 U            37 l            54 2
+ *        4 E            21 V            38 m            55 3
+ *        5 F            22 W            39 n            56 4
+ *        6 G            23 X            40 o            57 5
+ *        7 H            24 Y            41 p            58 6
+ *        8 I            25 Z            42 q            59 7
+ *        9 J            26 a            43 r            60 8
+ *       10 K            27 b            44 s            61 9
+ *       11 L            28 c            45 t            62 +
+ *       12 M            29 d            46 u            63 /
+ *       13 N            30 e            47 v
+ *       14 O            31 f            48 w         (pad) =
+ *       15 P            32 g            49 x
+ *       16 Q            33 h            50 y
+ *
+ * Special processing is performed if fewer than 24 bits are available
+ * at the end of the data being encoded.  A full encoding quantum is
+ * always completed at the end of a quantity.  When fewer than 24 input
+ * bits are available in an input group, zero bits are added (on the
+ * right) to form an integral number of 6-bit groups.  Padding at the
+ * end of the data is performed using the '=' character.
+ *
+ * Since all base64 input is an integral number of octets, only the
+ * following cases can arise:
+ *
+ *     (1) the final quantum of encoding input is an integral
+ *         multiple of 24 bits; here, the final unit of encoded
+ *    output will be an integral multiple of 4 characters
+ *    with no "=" padding,
+ *     (2) the final quantum of encoding input is exactly 8 bits;
+ *         here, the final unit of encoded output will be two
+ *    characters followed by two "=" padding characters, or
+ *     (3) the final quantum of encoding input is exactly 16 bits;
+ *         here, the final unit of encoded output will be three
+ *    characters followed by one "=" padding character.
+ */
+
+int
+mongoc_b64_ntop (uint8_t const *src,
+                 size_t         srclength,
+                 char          *target,
+                 size_t         targsize)
+{
+   size_t datalength = 0;
+   uint8_t input[3];
+   uint8_t output[4];
+   size_t i;
+
+   while (2 < srclength) {
+      input[0] = *src++;
+      input[1] = *src++;
+      input[2] = *src++;
+      srclength -= 3;
+
+      output[0] = input[0] >> 2;
+      output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
+      output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+      output[3] = input[2] & 0x3f;
+      Assert (output[0] < 64);
+      Assert (output[1] < 64);
+      Assert (output[2] < 64);
+      Assert (output[3] < 64);
+
+      if (datalength + 4 > targsize) {
+         return -1;
+      }
+      target[datalength++] = Base64[output[0]];
+      target[datalength++] = Base64[output[1]];
+      target[datalength++] = Base64[output[2]];
+      target[datalength++] = Base64[output[3]];
+   }
+
+   /* Now we worry about padding. */
+   if (0 != srclength) {
+      /* Get what's left. */
+      input[0] = input[1] = input[2] = '\0';
+
+      for (i = 0; i < srclength; i++) {
+         input[i] = *src++;
+      }
+      output[0] = input[0] >> 2;
+      output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
+      output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+      Assert (output[0] < 64);
+      Assert (output[1] < 64);
+      Assert (output[2] < 64);
+
+      if (datalength + 4 > targsize) {
+         return -1;
+      }
+      target[datalength++] = Base64[output[0]];
+      target[datalength++] = Base64[output[1]];
+
+      if (srclength == 1) {
+         target[datalength++] = Pad64;
+      } else{
+         target[datalength++] = Base64[output[2]];
+      }
+      target[datalength++] = Pad64;
+   }
+
+   if (datalength >= targsize) {
+      return -1;
+   }
+   target[datalength] = '\0'; /* Returned value doesn't count \0. */
+   return (int)datalength;
+}
+
+/* (From RFC1521 and draft-ietf-dnssec-secext-03.txt)
+   The following encoding technique is taken from RFC 1521 by Borenstein
+   and Freed.  It is reproduced here in a slightly edited form for
+   convenience.
+
+   A 65-character subset of US-ASCII is used, enabling 6 bits to be
+   represented per printable character. (The extra 65th character, "=",
+   is used to signify a special processing function.)
+
+   The encoding process represents 24-bit groups of input bits as output
+   strings of 4 encoded characters. Proceeding from left to right, a
+   24-bit input group is formed by concatenating 3 8-bit input groups.
+   These 24 bits are then treated as 4 concatenated 6-bit groups, each
+   of which is translated into a single digit in the base64 alphabet.
+
+   Each 6-bit group is used as an index into an array of 64 printable
+   characters. The character referenced by the index is placed in the
+   output string.
+
+                         Table 1: The Base64 Alphabet
+
+      Value Encoding  Value Encoding  Value Encoding  Value Encoding
+          0 A            17 R            34 i            51 z
+          1 B            18 S            35 j            52 0
+          2 C            19 T            36 k            53 1
+          3 D            20 U            37 l            54 2
+          4 E            21 V            38 m            55 3
+          5 F            22 W            39 n            56 4
+          6 G            23 X            40 o            57 5
+          7 H            24 Y            41 p            58 6
+          8 I            25 Z            42 q            59 7
+          9 J            26 a            43 r            60 8
+         10 K            27 b            44 s            61 9
+         11 L            28 c            45 t            62 +
+         12 M            29 d            46 u            63 /
+         13 N            30 e            47 v
+         14 O            31 f            48 w         (pad) =
+         15 P            32 g            49 x
+         16 Q            33 h            50 y
+
+   Special processing is performed if fewer than 24 bits are available
+   at the end of the data being encoded.  A full encoding quantum is
+   always completed at the end of a quantity.  When fewer than 24 input
+   bits are available in an input group, zero bits are added (on the
+   right) to form an integral number of 6-bit groups.  Padding at the
+   end of the data is performed using the '=' character.
+
+   Since all base64 input is an integral number of octets, only the
+   following cases can arise:
+
+       (1) the final quantum of encoding input is an integral
+           multiple of 24 bits; here, the final unit of encoded
+	   output will be an integral multiple of 4 characters
+	   with no "=" padding,
+       (2) the final quantum of encoding input is exactly 8 bits;
+           here, the final unit of encoded output will be two
+	   characters followed by two "=" padding characters, or
+       (3) the final quantum of encoding input is exactly 16 bits;
+           here, the final unit of encoded output will be three
+	   characters followed by one "=" padding character.
+   */
+
+/* skips all whitespace anywhere.
+   converts characters, four at a time, starting at (or after)
+   src from base - 64 numbers into three 8 bit bytes in the target area.
+   it returns the number of data bytes stored at the target, or -1 on error.
+ */
+
+static int mongoc_b64rmap_initialized = 0;
+static uint8_t mongoc_b64rmap[256];
+
+static const uint8_t mongoc_b64rmap_special = 0xf0;
+static const uint8_t mongoc_b64rmap_end = 0xfd;
+static const uint8_t mongoc_b64rmap_space = 0xfe;
+static const uint8_t mongoc_b64rmap_invalid = 0xff;
+
+/**
+ * Initializing the reverse map is not thread safe.
+ * Which is fine for NSD. For now...
+ **/
+void
+mongoc_b64_initialize_rmap (void)
+{
+	int i;
+	unsigned char ch;
+
+	/* Null: end of string, stop parsing */
+	mongoc_b64rmap[0] = mongoc_b64rmap_end;
+
+	for (i = 1; i < 256; ++i) {
+		ch = (unsigned char)i;
+		/* Whitespaces */
+		if (isspace(ch))
+			mongoc_b64rmap[i] = mongoc_b64rmap_space;
+		/* Padding: stop parsing */
+		else if (ch == Pad64)
+			mongoc_b64rmap[i] = mongoc_b64rmap_end;
+		/* Non-base64 char */
+		else
+			mongoc_b64rmap[i] = mongoc_b64rmap_invalid;
+	}
+
+	/* Fill reverse mapping for base64 chars */
+	for (i = 0; Base64[i] != '\0'; ++i)
+		mongoc_b64rmap[(uint8_t)Base64[i]] = i;
+
+	mongoc_b64rmap_initialized = 1;
+}
+
+static int
+mongoc_b64_pton_do(char const *src, uint8_t *target, size_t targsize)
+{
+	int tarindex, state, ch;
+	uint8_t ofs;
+
+	state = 0;
+	tarindex = 0;
+
+	while (1)
+	{
+		ch = *src++;
+		ofs = mongoc_b64rmap[ch];
+
+		if (ofs >= mongoc_b64rmap_special) {
+			/* Ignore whitespaces */
+			if (ofs == mongoc_b64rmap_space)
+				continue;
+			/* End of base64 characters */
+			if (ofs == mongoc_b64rmap_end)
+				break;
+			/* A non-base64 character. */
+			return (-1);
+		}
+
+		switch (state) {
+		case 0:
+			if ((size_t)tarindex >= targsize)
+				return (-1);
+			target[tarindex] = ofs << 2;
+			state = 1;
+			break;
+		case 1:
+			if ((size_t)tarindex + 1 >= targsize)
+				return (-1);
+			target[tarindex]   |=  ofs >> 4;
+			target[tarindex+1]  = (ofs & 0x0f)
+						<< 4 ;
+			tarindex++;
+			state = 2;
+			break;
+		case 2:
+			if ((size_t)tarindex + 1 >= targsize)
+				return (-1);
+			target[tarindex]   |=  ofs >> 2;
+			target[tarindex+1]  = (ofs & 0x03)
+						<< 6;
+			tarindex++;
+			state = 3;
+			break;
+		case 3:
+			if ((size_t)tarindex >= targsize)
+				return (-1);
+			target[tarindex] |= ofs;
+			tarindex++;
+			state = 0;
+			break;
+		default:
+			return (-1);
+		}
+	}
+
+	/*
+	 * We are done decoding Base-64 chars.  Let's see if we ended
+	 * on a byte boundary, and/or with erroneous trailing characters.
+	 */
+
+	if (ch == Pad64) {		/* We got a pad char. */
+		ch = *src++;		/* Skip it, get next. */
+		switch (state) {
+		case 0:		/* Invalid = in first position */
+		case 1:		/* Invalid = in second position */
+			return (-1);
+
+		case 2:		/* Valid, means one byte of info */
+			/* Skip any number of spaces. */
+			for ((void)NULL; ch != '\0'; ch = *src++)
+				if (mongoc_b64rmap[ch] != mongoc_b64rmap_space)
+					break;
+			/* Make sure there is another trailing = sign. */
+			if (ch != Pad64)
+				return (-1);
+			ch = *src++;		/* Skip the = */
+			/* Fall through to "single trailing =" case. */
+			/* FALLTHROUGH */
+
+		case 3:		/* Valid, means two bytes of info */
+			/*
+			 * We know this char is an =.  Is there anything but
+			 * whitespace after it?
+			 */
+			for ((void)NULL; ch != '\0'; ch = *src++)
+				if (mongoc_b64rmap[ch] != mongoc_b64rmap_space)
+					return (-1);
+
+			/*
+			 * Now make sure for cases 2 and 3 that the "extra"
+			 * bits that slopped past the last full byte were
+			 * zeros.  If we don't check them, they become a
+			 * subliminal channel.
+			 */
+			if (target[tarindex] != 0)
+				return (-1);
+		default:
+			break;
+		}
+	} else {
+		/*
+		 * We ended by seeing the end of the string.  Make sure we
+		 * have no partial bytes lying around.
+		 */
+		if (state != 0)
+			return (-1);
+	}
+
+	return (tarindex);
+}
+
+
+static int
+mongoc_b64_pton_len(char const *src)
+{
+	int tarindex, state, ch;
+	uint8_t ofs;
+
+	state = 0;
+	tarindex = 0;
+
+	while (1)
+	{
+		ch = *src++;
+		ofs = mongoc_b64rmap[ch];
+
+		if (ofs >= mongoc_b64rmap_special) {
+			/* Ignore whitespaces */
+			if (ofs == mongoc_b64rmap_space)
+				continue;
+			/* End of base64 characters */
+			if (ofs == mongoc_b64rmap_end)
+				break;
+			/* A non-base64 character. */
+			return (-1);
+		}
+
+		switch (state) {
+		case 0:
+			state = 1;
+			break;
+		case 1:
+			tarindex++;
+			state = 2;
+			break;
+		case 2:
+			tarindex++;
+			state = 3;
+			break;
+		case 3:
+			tarindex++;
+			state = 0;
+			break;
+		default:
+			return (-1);
+		}
+	}
+
+	/*
+	 * We are done decoding Base-64 chars.  Let's see if we ended
+	 * on a byte boundary, and/or with erroneous trailing characters.
+	 */
+
+	if (ch == Pad64) {		/* We got a pad char. */
+		ch = *src++;		/* Skip it, get next. */
+		switch (state) {
+		case 0:		/* Invalid = in first position */
+		case 1:		/* Invalid = in second position */
+			return (-1);
+
+		case 2:		/* Valid, means one byte of info */
+			/* Skip any number of spaces. */
+			for ((void)NULL; ch != '\0'; ch = *src++)
+				if (mongoc_b64rmap[ch] != mongoc_b64rmap_space)
+					break;
+			/* Make sure there is another trailing = sign. */
+			if (ch != Pad64)
+				return (-1);
+			ch = *src++;		/* Skip the = */
+			/* Fall through to "single trailing =" case. */
+			/* FALLTHROUGH */
+
+		case 3:		/* Valid, means two bytes of info */
+			/*
+			 * We know this char is an =.  Is there anything but
+			 * whitespace after it?
+			 */
+			for ((void)NULL; ch != '\0'; ch = *src++)
+				if (mongoc_b64rmap[ch] != mongoc_b64rmap_space)
+					return (-1);
+
+		default:
+			break;
+		}
+	} else {
+		/*
+		 * We ended by seeing the end of the string.  Make sure we
+		 * have no partial bytes lying around.
+		 */
+		if (state != 0)
+			return (-1);
+	}
+
+	return (tarindex);
+}
+
+
+int
+mongoc_b64_pton(char const *src, uint8_t *target, size_t targsize)
+{
+	if (!mongoc_b64rmap_initialized)
+		mongoc_b64_initialize_rmap ();
+
+	if (target)
+		return mongoc_b64_pton_do (src, target, targsize);
+	else
+		return mongoc_b64_pton_len (src);
+}
+

--- a/lualib/mongo.lua
+++ b/lualib/mongo.lua
@@ -4,6 +4,7 @@ local socketchannel	= require "socketchannel"
 local skynet = require "skynet"
 local driver = require "mongo.driver"
 local md5 =	require	"md5"
+local mongo_auth = require "mongo_auth"
 local rawget = rawget
 local assert = assert
 
@@ -182,6 +183,72 @@ function mongo_client:auth(user,password)
 	local key =	md5.sumhexa(string.format("%s%s%s",result.nonce,user,password))
 	local result= self:runCommand ("authenticate",1,"user",user,"nonce",result.nonce,"key",key)
 	return result.ok ==	1
+end
+
+function mongo_client:auth_scram_sha1(username,password)
+	local user = string.gsub(string.gsub(username, '=', '=3D'), ',' , '=2C')
+	local nonce = mongo_auth.encode_base64(string.sub(tostring(math.random()), 3 , 14))
+	local first_bare = "n="  .. user .. ",r="  .. nonce
+	local sasl_start_payload = mongo_auth.encode_base64("n,," .. first_bare)
+	local r
+	
+	r = self:runCommand("saslStart",1,"autoAuthorize",1,"mechanism","SCRAM-SHA-1","payload",sasl_start_payload)
+	if r.ok ~= 1 then
+		return false
+	end
+	
+	local conversationId = r['conversationId']
+	local server_first = r['payload']
+	local parsed_s = mongo_auth.decode_base64(server_first)
+	local parsed_t = {}
+	for k, v in string.gmatch(parsed_s, "(%w+)=([^,]*)") do
+		parsed_t[k] = v
+	end
+	local iterations = tonumber(parsed_t['i'])
+	local salt = parsed_t['s']
+	local rnonce = parsed_t['r']
+	
+	if not string.sub(rnonce, 1, 12) == nonce then
+		skynet.error("Server returned an invalid nonce.")
+		return false
+	end
+	local without_proof = "c=biws,r=" .. rnonce
+	local pbkdf2_key = md5.sumhexa(string.format("%s:mongo:%s",username,password))
+	local salted_pass = mongo_auth.salt_password(pbkdf2_key, mongo_auth.decode_base64(salt), iterations)
+	local client_key = mongo_auth.hmac_sha1(salted_pass, "Client Key")
+	local stored_key = mongo_auth.sha1_bin(client_key)
+	local auth_msg = first_bare .. ',' .. parsed_s .. ',' .. without_proof
+	local client_sig = mongo_auth.hmac_sha1(stored_key, auth_msg)
+	local client_key_xor_sig = mongo_auth.xor_str(client_key, client_sig)
+	local client_proof = "p=" .. mongo_auth.encode_base64(client_key_xor_sig)
+	local client_final = mongo_auth.encode_base64(without_proof .. ',' .. client_proof)
+	local server_key = mongo_auth.hmac_sha1(salted_pass, "Server Key")
+	local server_sig = mongo_auth.encode_base64(mongo_auth.hmac_sha1(server_key, auth_msg))
+	
+	r = self:runCommand("saslContinue",1,"conversationId",conversationId,"payload",client_final)
+	if r.ok ~= 1 then
+		return false
+	end
+	parsed_s = mongo_auth.decode_base64(r['payload'])
+	parsed_t = {}
+	for k, v in string.gmatch(parsed_s, "(%w+)=([^,]*)") do
+		parsed_t[k] = v
+	end
+	if parsed_t['v'] ~= server_sig then
+		skynet.error("Server returned an invalid signature.")
+		return false
+	end
+	if not r.done then
+		r = self:runCommand("saslContinue",1,"conversationId",conversationId,"payload",mongo_auth.encode_base64(""))
+		if r.ok ~= 1 then
+			return false
+		end
+		if not r.done then
+			skynet.error("SASL conversation failed to complete.")
+			return false
+		end
+	end
+	return true
 end
 
 function mongo_client:logout()

--- a/test/testmongoa.lua
+++ b/test/testmongoa.lua
@@ -1,0 +1,8 @@
+local skynet = require "skynet"
+local mongo = require "mongo"
+
+skynet.start(function()
+	local db = mongo.client({host = "127.0.0.1", port=3717})
+	skynet.error(db:auth_scram_sha1("game", "q123456"))
+	skynet.exit()
+end)

--- a/test/testmongoa.lua
+++ b/test/testmongoa.lua
@@ -3,6 +3,6 @@ local mongo = require "mongo"
 
 skynet.start(function()
 	local db = mongo.client({host = "127.0.0.1", port=3717})
-	skynet.error(db:auth_scram_sha1("game", "q123456"))
+	skynet.error(db:auth_scram_sha1("root", "123456"))
 	skynet.exit()
 end)


### PR DESCRIPTION
- add openssl submodule for HMAC & SHA1
- add mongoc-b64.c from mongo-c-driver for base64 encode & decode
- add auth_scram_sha1 function for mongo_client
- add a testsuit for auth_scram_sha1