### PR TITLE
修正mongo lua driver创建组合索引时索引顺序不符合预期的bug

### DIFF
--- a/lualib/mongo.lua
+++ b/lualib/mongo.lua
@@ -318,22 +318,25 @@ function mongo_cursor:count(with_limit_and_skip)
 end
 
 
--- collection:createIndex({username = 1}, {unique = true})
-function mongo_collection:createIndex(keys, option)
+-- collection:createIndex({username = 1},{index2 = 1}, {unique = true})
+function mongo_collection:createIndex(...)
+	local paramLen = select("#", ...)
+	assert(paramLen >= 2)
+	local option = select(paramLen, ...)
 	local name = option.name
 	option.name = nil
 
+	local doc = {key = {}}
 	if not name then
-		for k, v in pairs(keys) do
-			name = (name == nil) and k or (name .. "_" .. k)
-			name = name  .. "_" .. v
-		end
+	    for i = 1 , paramLen - 1 do
+	    	for k,v in pairs(select(i, ...)) do
+		        doc.key[k] = v
+				name = (name == nil) and k or (name .. "_" .. k)
+				name = name  .. "_" .. v
+	    	end
+	    end
 	end
-
-
-	local doc = {};
 	doc.name = name
-	doc.key = keys
 	for k, v in pairs(option) do
 		doc[k] = v
 	end

--- a/lualib/mongo.lua
+++ b/lualib/mongo.lua
@@ -325,18 +325,19 @@ function mongo_collection:createIndex(...)
 	local option = select(paramLen, ...)
 	local name = option.name
 	option.name = nil
-
 	local doc = {key = {}}
 	if not name then
 	    for i = 1 , paramLen - 1 do
 	    	for k,v in pairs(select(i, ...)) do
-		        doc.key[k] = v
+	    		table.insert(doc.key, k)
+	    		table.insert(doc.key, v)
 				name = (name == nil) and k or (name .. "_" .. k)
 				name = name  .. "_" .. v
 	    	end
 	    end
 	end
 	doc.name = name
+	doc.key = bson_encode_order(table.unpack(doc.key))
 	for k, v in pairs(option) do
 		doc[k] = v
 	end


### PR DESCRIPTION
在原本createIndex接口中 keys参数传递方式为function createIndex({key1 = 1, key2 = 1},{unique = true})
由于table的hash导致key的拼接到Bson中无序,所以修改了实现的方式
新的接口将参数传入改为function createIndex({key1 =1},{key2 =2},{unique = true})的方式
函数实现兼容旧的接口 但是如果使用旧的方式传递key值 这个bug将不能被修复.原因同上:table的hash无序导致
感觉群友@joe指点出第一次修改的bug并提供修改思路