### PR TITLE
A simple advice that the 'debug_console' service can be modified for custom ip address and port.

### DIFF
--- a/examples/main.lua
+++ b/examples/main.lua
@@ -9,7 +9,7 @@ skynet.start(function()
 	if not skynet.getenv "daemon" then
 		local console = skynet.newservice("console")
 	end
-	skynet.newservice("debug_console",8000)
+	skynet.newservice("debug_console", "127.0.0.1", 8000)
 	skynet.newservice("simpledb")
 	local watchdog = skynet.newservice("watchdog")
 	skynet.call(watchdog, "lua", "start", {

--- a/service/debug_console.lua
+++ b/service/debug_console.lua
@@ -7,7 +7,17 @@ local memory = require "memory"
 local httpd = require "http.httpd"
 local sockethelper = require "http.sockethelper"
 
-local port = tonumber(...)
+local function variableargs(...)
+    local args = {}
+    for i = 1, select("#", ...) do
+        args[i] = select(i, ...)
+    end
+    return args
+end
+
+local args = variableargs(...)
+local ip, port = args[1] or "127.0.0.1", args[2] or 8888
+
 local COMMAND = {}
 
 local function format_table(t)
@@ -103,8 +113,8 @@ local function console_main_loop(stdin, print)
 end
 
 skynet.start(function()
-	local listen_socket = socket.listen ("127.0.0.1", port)
-	skynet.error("Start debug console at 127.0.0.1 " .. port)
+	local listen_socket = socket.listen (ip, port)
+	skynet.error(string.format("Start debug console at %s:%d", ip, port))
 	socket.start(listen_socket , function(id, addr)
 		local function print(...)
 			local t = { ... }


### PR DESCRIPTION
Hi, cloudwu!
  I'm a new fan to skynet.  I'm learning and start to use skynet for our new project. But when I deployed our new project to aliyun server, I found that is not conveniency for use debug_console service because of the fixed listening ip address and port. So I modified it. 
  Best wishes for you and skynet!