### PR TITLE
add snax.profile_info interface

### DIFF
--- a/lualib/snax.lua
+++ b/lualib/snax.lua
@@ -166,4 +166,9 @@ function snax.printf(fmt, ...)
 	skynet.error(string.format(fmt, ...))
 end
 
+function snax.profile_info(obj)
+	local t = snax.interface(obj.type)
+	return skynet_call(obj.handle, "snax", t.system.profile)
+end
+
 return snax

--- a/lualib/snax/interface.lua
+++ b/lualib/snax/interface.lua
@@ -35,7 +35,7 @@ return function (name , G, loader)
 	local env = setmetatable({} , { __index = temp_global })
 	local func = {}
 
-	local system = { "init", "exit", "hotfix" }
+	local system = { "init", "exit", "hotfix", "profile"}
 
 	do
 		for k, v in ipairs(system) do

--- a/service/snaxd.lua
+++ b/service/snaxd.lua
@@ -54,6 +54,8 @@ skynet.start(function()
 			if command == "hotfix" then
 				local hotfix = require "snax.hotfix"
 				skynet.ret(skynet.pack(hotfix(func, ...)))
+			elseif command == "profile" then
+				skynet.ret(skynet.pack(profile_table))
 			elseif command == "init" then
 				assert(not init, "Already init")
 				local initfunc = method[4] or function() end


### PR DESCRIPTION
在某些情况下，需要设置snax 服务的info_func, 设置之后就不能方便的获取snaxd 中记录的profile_table了。
于是,增加snax.profile_info 接口
```
snax.profile_info(some_snax_service)
```
 