### PR TITLE
add debug "detail" command: look all task traceback, include new coroutine

### DIFF
--- a/lualib/skynet/debug.lua
+++ b/lualib/skynet/debug.lua
@@ -78,6 +78,12 @@ local function init(skynet, export)
 			-- no return, raise error when exit
 		end
 
+		function dbgcmd.DETAIL()
+			local detail = {}
+			skynet.detail(detail)
+			skynet.ret(skynet.pack(detail))
+		end
+
 		return dbgcmd
 	end -- function init_dbgcmd
 

--- a/service/debug_console.lua
+++ b/service/debug_console.lua
@@ -155,6 +155,7 @@ function COMMAND.help()
 		shrtbl = "Show shared short string table info",
 		ping = "ping address",
 		call = "call address ...",
+		detail = "task address : show all service task traceback",
 	}
 end
 
@@ -331,4 +332,9 @@ function COMMANDX.call(cmd)
 	end
 	local rets = table.pack(skynet.call(address, "lua", table.unpack(args, 2, args.n)))
 	return rets
+end
+
+function COMMAND.detail(fd, address)
+	address = adjust_address(address)
+	return skynet.call(address,"debug","DETAIL")
 end


### PR DESCRIPTION
生产环境遇到一个代码bug，由skynet.timeout发起的延时太久，导致coroutine堆积，此时在debug console中用task命令遇到大量任务trackback信息为空，并不能得到有用的信息。于是加了一个命令“detail”，在coroutine产生或挂起时立即将traceback记下，用户执行detail命令时，将这些信息输出。可以考虑和task合并，或保留一条新命令。