### PR TITLE
一些增强易用性的更改

### DIFF
--- a/lualib/skynet.lua
+++ b/lualib/skynet.lua
@@ -256,6 +256,8 @@ function skynet.timeout(ti, func)
 	local co = co_create(func)
 	assert(session_id_coroutine[session] == nil)
 	session_id_coroutine[session] = co
+
+        return co
 end
 
 function skynet.sleep(ti)
@@ -645,7 +647,7 @@ function skynet.task(ret)
 	local t = 0
 	for session,co in pairs(session_id_coroutine) do
 		if ret then
-			ret[session] = debug.traceback(co)
+			ret[session] = co
 		end
 		t = t + 1
 	end

--- a/lualib/snax/hotfix.lua
+++ b/lualib/snax/hotfix.lua
@@ -53,8 +53,8 @@ local function collect_all_uv(funcs)
 end
 
 local function loader(source)
-	return function (filename, ...)
-		return load(source, "=patch", ...)
+	return function (path, name, G)
+		return load(source, "=patch", "bt", G)
 	end
 end
 

--- a/lualib/snax/hotfix.lua
+++ b/lualib/snax/hotfix.lua
@@ -68,10 +68,10 @@ local function find_func(funcs, group , name)
 end
 
 local dummy_env = {}
+for k,v in pairs(_ENV) do dummy_env[k] = v end
 
-local function patch_func(funcs, global, group, name, f)
-	local desc = assert(find_func(funcs, group, name) , string.format("Patch mismatch %s.%s", group, name))
-	local i = 1
+local function _patch(global, f)
+        local i = 1
 	while true do
 		local name, value = debug.getupvalue(f, i)
 		if name == nil then
@@ -81,9 +81,18 @@ local function patch_func(funcs, global, group, name, f)
 			if old_uv then
 				debug.upvaluejoin(f, i, old_uv.func, old_uv.index)
 			end
+                else
+                    if type(value) == "function" then
+                        _patch(global, value)
+                    end
 		end
 		i = i + 1
 	end
+end
+
+local function patch_func(funcs, global, group, name, f)
+	local desc = assert(find_func(funcs, group, name) , string.format("Patch mismatch %s.%s", group, name))
+        _patch(global, f)
 	desc[4] = f
 end
 

--- a/lualib/snax/interface.lua
+++ b/lualib/snax/interface.lua
@@ -1,8 +1,24 @@
 local skynet = require "skynet"
 
+local function dft_loader(path, name, G)
+    local errlist = {}
+
+    for pat in string.gmatch(path,"[^;]+") do
+        local filename = string.gsub(pat, "?", name)
+        local f , err = loadfile(filename, "bt", G)
+        if f then
+            return f, pat
+        else
+            table.insert(errlist, err)
+        end
+    end
+
+    error(table.concat(errlist, "\n"))
+end
+
 return function (name , G, loader)
-	loader = loader or loadfile
-	local mainfunc
+       loader = loader or dft_loader
+       local mainfunc
 
 	local function func_id(id, group)
 		local tmp = {}
@@ -61,27 +77,8 @@ return function (name , G, loader)
 
 	local pattern
 
-	do
-		local path = assert(skynet.getenv "snax" , "please set snax in config file")
-
-		local errlist = {}
-
-		for pat in string.gmatch(path,"[^;]+") do
-			local filename = string.gsub(pat, "?", name)
-			local f , err = loader(filename, "bt", G)
-			if f then
-				pattern = pat
-				mainfunc = f
-				break
-			else
-				table.insert(errlist, err)
-			end
-		end
-
-		if mainfunc == nil then
-			error(table.concat(errlist, "\n"))
-		end
-	end
+        local path = assert(skynet.getenv "snax" , "please set snax in config file")
+        mainfunc, pattern = loader(path, name, G)
 
 	setmetatable(G,	{ __index = env , __newindex = init_system })
 	local ok, err = pcall(mainfunc)

--- a/service/cdummy.lua
+++ b/service/cdummy.lua
@@ -31,6 +31,10 @@ local function response_name(name)
 	end
 end
 
+function harbor.watch(addr)
+    -- donothing
+end
+
 function harbor.REGISTER(name, handle)
 	assert(globalname[name] == nil)
 	globalname[name] = handle

--- a/service/cslave.lua
+++ b/service/cslave.lua
@@ -177,7 +177,7 @@ local function monitor_harbor(master_fd)
 	end
 end
 
-function harbor.watch(addr)
+function harbor.watch(_,addr)
     table.insert(watchers, addr)
 end
 

--- a/service/snaxd.lua
+++ b/service/snaxd.lua
@@ -5,7 +5,9 @@ local profile = require "profile"
 local snax = require "snax"
 
 local snax_name = tostring(...)
-local func, pattern = snax_interface(snax_name, _ENV)
+local loaderpath = skynet.getenv"snax_loader"
+local loader = loaderpath and assert(dofile(loaderpath)) or require"snax.loader"
+local func, pattern = snax_interface(snax_name, _ENV, loader)
 local snax_path = pattern:sub(1,pattern:find("?", 1, true)-1) .. snax_name ..  "/"
 package.path = snax_path .. "?.lua;" .. package.path
 

--- a/service/snaxd.lua
+++ b/service/snaxd.lua
@@ -49,6 +49,11 @@ end
 skynet.start(function()
 	local init = false
 	local function dispatcher( session , source , id, ...)
+                if id == "name" then
+                    skynet.ret(skynet.pack(snax_name))
+                    return
+                end
+
 		local method = func[id]
 
 		if method[2] == "system" then


### PR DESCRIPTION
以下所有修改都是兼容的（除了第5条):

1. snaxd增加一个查询当前服务名字的方法

2. snaxd interface 支持定制loader(增加这个功能是因为我需要在加载snax的时候就把服务所在目录加到loader路径里，而不是load完后再加。)

3. 为cslave增加watch方法，这个在正常关闭服务器的时候有用.

4. snax hotfix 递归的patch_func.

比如考虑如下场景:

local lobster

local function bar()
      ...
      local _ = lobster  -- reference lobster here
      .....
end
function response.foo()
    ... 
    bar()
   ...
end

这里我要热更新bar函数，需要让bar函数join老的lobster,之前那样是办不到的。

5. skynet.tasks 返回挂起的coroutine 而不是它的traceback。(需要这个功能是因为退出一个服务的时候，我想统计一下它有多少服务挂起，并和我已知的会挂起的coroutine做比较)