### PR TITLE
一些加强易用性的修改

### DIFF
--- a/lualib-src/lua-crypt.c
+++ b/lualib-src/lua-crypt.c
@@ -494,7 +494,7 @@ static int
 lfromhex(lua_State *L) {
 	size_t sz = 0;
 	const char * text = luaL_checklstring(L, 1, &sz);
-	if (sz & 2) {
+	if (sz & 1) {
 		return luaL_error(L, "Invalid hex text size %d", (int)sz);
 	}
 	char tmp[SMALL_CHUNK];

--- a/lualib/snax.lua
+++ b/lualib/snax.lua
@@ -1,5 +1,6 @@
 local skynet = require "skynet"
 local snax_interface = require "snax.interface"
+local sysfunc = require"snax.sysfunc"
 
 local snax = {}
 local typeclass = {}
@@ -147,6 +148,12 @@ end
 
 function snax.exit(...)
 	snax.kill(snax.self(), ...)
+end
+
+function snax.name(handle)
+    handle = handle or skynet.self()
+
+    return skynet_call(handle, "snax",sysfunc.name)
 end
 
 local function test_result(ok, ...)

--- a/lualib/snax.lua
+++ b/lualib/snax.lua
@@ -1,6 +1,5 @@
 local skynet = require "skynet"
 local snax_interface = require "snax.interface"
-local sysfunc = require"snax.sysfunc"
 
 local snax = {}
 local typeclass = {}
@@ -151,6 +150,7 @@ function snax.exit(...)
 end
 
 function snax.name(handle)
+    local sysfunc = require"snax.sysfunc"
     handle = handle or skynet.self()
 
     return skynet_call(handle, "snax",sysfunc.name)

--- a/lualib/snax/hotfix.lua
+++ b/lualib/snax/hotfix.lua
@@ -68,10 +68,10 @@ local function find_func(funcs, group , name)
 end
 
 local dummy_env = {}
+for k,v in pairs(_ENV) do dummy_env[k] = v end
 
-local function patch_func(funcs, global, group, name, f)
-	local desc = assert(find_func(funcs, group, name) , string.format("Patch mismatch %s.%s", group, name))
-	local i = 1
+local function _patch(global, f)
+        local i = 1
 	while true do
 		local name, value = debug.getupvalue(f, i)
 		if name == nil then
@@ -81,9 +81,18 @@ local function patch_func(funcs, global, group, name, f)
 			if old_uv then
 				debug.upvaluejoin(f, i, old_uv.func, old_uv.index)
 			end
+                else
+                    if type(value) == "function" then
+                        _patch(global, value)
+                    end
 		end
 		i = i + 1
 	end
+end
+
+local function patch_func(funcs, global, group, name, f)
+	local desc = assert(find_func(funcs, group, name) , string.format("Patch mismatch %s.%s", group, name))
+        _patch(global, f)
 	desc[4] = f
 end
 

--- a/lualib/snax/interface.lua
+++ b/lualib/snax/interface.lua
@@ -1,8 +1,24 @@
 local skynet = require "skynet"
 
+local function dft_loader(path, name, G)
+    local errlist = {}
+
+    for pat in string.gmatch(path,"[^;]+") do
+        local filename = string.gsub(pat, "?", name)
+        local f , err = loadfile(filename, "bt", G)
+        if f then
+            return f, pat
+        else
+            table.insert(errlist, err)
+        end
+    end
+
+    error(table.concat(errlist, "\n"))
+end
+
 return function (name , G, loader)
-	loader = loader or loadfile
-	local mainfunc
+       loader = loader or dft_loader
+       local mainfunc
 
 	local function func_id(id, group)
 		local tmp = {}
@@ -61,27 +77,8 @@ return function (name , G, loader)
 
 	local pattern
 
-	do
-		local path = assert(skynet.getenv "snax" , "please set snax in config file")
-
-		local errlist = {}
-
-		for pat in string.gmatch(path,"[^;]+") do
-			local filename = string.gsub(pat, "?", name)
-			local f , err = loader(filename, "bt", G)
-			if f then
-				pattern = pat
-				mainfunc = f
-				break
-			else
-				table.insert(errlist, err)
-			end
-		end
-
-		if mainfunc == nil then
-			error(table.concat(errlist, "\n"))
-		end
-	end
+        local path = assert(skynet.getenv "snax" , "please set snax in config file")
+        mainfunc, pattern = loader(path, name, G)
 
 	setmetatable(G,	{ __index = env , __newindex = init_system })
 	local ok, err = xpcall(mainfunc, debug.traceback)

--- a/lualib/snax/interface.lua
+++ b/lualib/snax/interface.lua
@@ -84,7 +84,7 @@ return function (name , G, loader)
 	end
 
 	setmetatable(G,	{ __index = env , __newindex = init_system })
-	local ok, err = pcall(mainfunc)
+	local ok, err = xpcall(mainfunc, debug.traceback)
 	setmetatable(G, nil)
 	assert(ok,err)
 

--- a/lualib/snax/interface.lua
+++ b/lualib/snax/interface.lua
@@ -1,3 +1,4 @@
+local system = require"snax.sysfunc"
 local skynet = require "skynet"
 
 local function dft_loader(path, name, G)
@@ -51,11 +52,8 @@ return function (name , G, loader)
 	local env = setmetatable({} , { __index = temp_global })
 	local func = {}
 
-	local system = { "init", "exit", "hotfix" }
-
 	do
 		for k, v in ipairs(system) do
-			system[v] = k
 			func[k] = { k , "system", v }
 		end
 	end

--- a/lualib/snax/sysfunc.lua
+++ b/lualib/snax/sysfunc.lua
@@ -1,0 +1,9 @@
+local system = { "init", "exit", "hotfix","name" }
+
+do
+        for k, v in ipairs(system) do
+                system[v] = k
+        end
+end
+
+return system

--- a/lualib/snax/sysfunc.lua
+++ b/lualib/snax/sysfunc.lua
@@ -1,4 +1,4 @@
-local system = { "init", "exit", "hotfix","name" }
+local system = { "init", "exit", "hotfix","profile","name" }
 
 do
         for k, v in ipairs(system) do

--- a/service/cdummy.lua
+++ b/service/cdummy.lua
@@ -31,6 +31,10 @@ local function response_name(name)
 	end
 end
 
+function harbor.watch(addr)
+    -- donothing
+end
+
 function harbor.REGISTER(name, handle)
 	assert(globalname[name] == nil)
 	globalname[name] = handle

--- a/service/cslave.lua
+++ b/service/cslave.lua
@@ -177,7 +177,7 @@ local function monitor_harbor(master_fd)
 	end
 end
 
-function harbor.watch(addr)
+function harbor.watch(_,addr)
     table.insert(watchers, addr)
 end
 

--- a/service/snaxd.lua
+++ b/service/snaxd.lua
@@ -5,7 +5,9 @@ local profile = require "profile"
 local snax = require "snax"
 
 local snax_name = tostring(...)
-local func, pattern = snax_interface(snax_name, _ENV)
+local loaderpath = skynet.getenv"snax_loader"
+local loader = loaderpath and assert(dofile(loaderpath)) or require"snax.loader"
+local func, pattern = snax_interface(snax_name, _ENV, loader)
 local snax_path = pattern:sub(1,pattern:find("?", 1, true)-1) .. snax_name ..  "/"
 package.path = snax_path .. "?.lua;" .. package.path
 

--- a/service/snaxd.lua
+++ b/service/snaxd.lua
@@ -49,6 +49,11 @@ end
 skynet.start(function()
 	local init = false
 	local function dispatcher( session , source , id, ...)
+                if id == "name" then
+                    skynet.ret(skynet.pack(snax_name))
+                    return
+                end
+
 		local method = func[id]
 
 		if method[2] == "system" then

--- a/service/snaxd.lua
+++ b/service/snaxd.lua
@@ -66,8 +66,11 @@ skynet.start(function()
 				end)
 				init = true
                         elseif command == "name" then
-                                local func = method[4] or function () return SERVICE_NAME end
-                                skynet.ret(skynet.pack(func()))
+                                if method[4] then
+                                    skynet.ret(skynet.pack(method[4]()))
+                                else
+                                    skynet.ret(skynet.pack(SERVICE_NAME))
+                                end
 			else
 				assert(init, "Never init")
 				assert(command == "exit")

--- a/service/snaxd.lua
+++ b/service/snaxd.lua
@@ -49,11 +49,6 @@ end
 skynet.start(function()
 	local init = false
 	local function dispatcher( session , source , id, ...)
-                if id == "name" then
-                    skynet.ret(skynet.pack(snax_name))
-                    return
-                end
-
 		local method = func[id]
 
 		if method[2] == "system" then
@@ -70,6 +65,9 @@ skynet.start(function()
 					return profile_table
 				end)
 				init = true
+                        elseif command == "name" then
+                                local func = method[4] or function () return SERVICE_NAME end
+                                skynet.ret(skynet.pack(func()))
 			else
 				assert(init, "Never init")
 				assert(command == "exit")


### PR DESCRIPTION
以下所有修改都是兼容的:

1. snaxd增加一个查询当前服务名字的方法

2. snaxd interface 支持定制loader(增加这个功能是因为我需要在加载snax的时候就把服务所在目录加到loader路径里，而不是load完后再加。)

3. 为cslave增加watch方法，这个在正常关闭服务器的时候有用.

4. snax hotfix 递归的patch_func.

比如考虑如下场景:

```
local lobster

local function bar()
-- ...
    local _ = lobster -- reference lobster here
-- .....
end

function response.foo()
  -- ...
    bar()
    -- ...
end
```

这里我要热更新bar函数，需要让bar函数join老的lobster,之前那样是办不到的。


