### PR TITLE
config script args

### DIFF
--- a/skynet-src/skynet_main.c
+++ b/skynet-src/skynet_main.c
@@ -90,7 +90,7 @@ static const char * load_config = "\
 	code = string.gsub(code, \'%$([%w_%d]+)\', getenv)\
 	f:close()\
 	local result = {}\
-	assert(load(code,\'=(load)\',\'t\',result))()\
+	assert(load(code,\'=(load)\',\'t\',result))(...)\
 	return result\
 ";
 
@@ -119,8 +119,11 @@ main(int argc, char *argv[]) {
 	int err = luaL_loadstring(L, load_config);
 	assert(err == LUA_OK);
 	lua_pushstring(L, config_file);
+	for (int i = 2; i < argc; ++i) {
+		lua_pushstring(L, argv[i]);
+	}
 
-	err = lua_pcall(L, 1, 1, 0);
+	err = lua_pcall(L, argc-1, 1, 0);
 	if (err) {
 		fprintf(stderr,"%s\n",lua_tostring(L,-1));
 		lua_close(L);


### PR DESCRIPTION
由于我们在不同节点上的config中有一大半内容是重复的，因此想尝试使用统一的config脚本，用命令行参数来区分不同节点，可以在同一个config脚本中，通过条件判断设置不同节点的IP、端口、初始服务等配置。

当然，这个需求也可以通过设置环境变量来实现，但不如传参来的直接、简洁。因此做了一点小改动，希望采纳。