### PR TITLE
skynet.info_func 函数有多个返回值的情况

### DIFF
--- a/service/debug_console.lua
+++ b/service/debug_console.lua
@@ -59,31 +59,38 @@ local function docmd(cmdline, print, fd)
 	local split = split_cmdline(cmdline)
 	local command = split[1]
 	local cmd = COMMAND[command]
-	local ok, list
+	local args
 	if cmd then
-		ok, list = pcall(cmd, table.unpack(split,2))
+		args = { pcall(cmd, table.unpack(split,2)) }
 	else
 		cmd = COMMANDX[command]
 		if cmd then
 			split.fd = fd
 			split[1] = cmdline
-			ok, list = pcall(cmd, split)
+			args = { pcall(cmd, split) }
 		else
+			args = {}
 			print("Invalid command, type help for command list")
 		end
 	end
 
+	local ok, err = args[1], args[2]
+
 	if ok then
-		if list then
-			if type(list) == "string" then
-				print(list)
-			else
-				dump_list(print, list)
+		for i=2, #args do
+			local list = args[i]
+			if list then
+				local t = type(list)
+				if t == "string" or t == "number" then
+					print(list)
+				else
+					dump_list(print, list)
+				end
 			end
 		end
 		print("<CMD OK>")
 	else
-		print(list)
+		print(err)
 		print("<CMD Error>")
 	end
 end


### PR DESCRIPTION
在 debug_console 中发送指令给服务之后，只能打印出服务返回结果的第一个值。

改成有多少个打多少个