### PR TITLE
error report on sharedata newindex

### DIFF
--- a/lualib/sharedata/corelib.lua
+++ b/lualib/sharedata/corelib.lua
@@ -71,6 +71,10 @@ local function getcobj(self)
 	return obj
 end
 
+function meta:__newindex(key, value)
+	error ("Error newindex, the key [" .. genkey(self) .. "]")
+end
+
 function meta:__index(key)
 	local obj = getcobj(self)
 	local v = index(obj, key)
@@ -78,7 +82,7 @@ function meta:__index(key)
 		local children = self.__cache
 		if children == nil then
 			children = {}
-			self.__cache = children
+			rawset(self, "__cache", children)
 		end
 		local r = children[key]
 		if r then


### PR DESCRIPTION
有同学不小心把sharedata返回的table直接拿来用了。所以给sharedata对象增加了newindex，newindex的时候抛出error，方便排查问题。
麻烦云风看看ok不，thanks