### PR TITLE
change SOCKET_WARNING msg, add SOCKET_EMPTY msg & api

### DIFF
--- a/examples/watchdog.lua
+++ b/examples/watchdog.lua
@@ -36,6 +36,10 @@ function SOCKET.warning(fd, size)
 	print("socket warning", fd, size)
 end
 
+function SOCKET.empty(fd)
+	print("socket emtpy", fd)
+end
+
 function SOCKET.data(fd, msg)
 end
 

--- a/lualib-src/lua-netpack.c
+++ b/lualib-src/lua-netpack.c
@@ -22,6 +22,7 @@
 #define TYPE_OPEN 4
 #define TYPE_CLOSE 5
 #define TYPE_WARNING 6
+#define TYPE_EMPTY 7
 
 /*
 	Each package is uint16 + data , uint16 (serialized in big-endian) is the number of bytes comprising the data .
@@ -380,6 +381,10 @@ lfilter(lua_State *L) {
 		lua_pushinteger(L, message->id);
 		lua_pushinteger(L, message->ud);
 		return 4;
+	case SKYNET_SOCKET_TYPE_EMPTY:
+		lua_pushvalue(L, lua_upvalueindex(TYPE_EMPTY));
+		lua_pushinteger(L, message->id);
+		return 3;
 	default:
 		// never get here
 		return 1;
@@ -483,8 +488,9 @@ luaopen_netpack(lua_State *L) {
 	lua_pushliteral(L, "open");
 	lua_pushliteral(L, "close");
 	lua_pushliteral(L, "warning");
+	lua_pushliteral(L, "empty");
 
-	lua_pushcclosure(L, lfilter, 6);
+	lua_pushcclosure(L, lfilter, 7);
 	lua_setfield(L, -2, "filter");
 
 	return 1;

--- a/lualib-src/lua-socket.c
+++ b/lualib-src/lua-socket.c
@@ -567,8 +567,9 @@ lsendlow(lua_State *L) {
 	int id = luaL_checkinteger(L, 1);
 	int sz = 0;
 	void *buffer = get_buffer(L, 2, &sz);
-	skynet_socket_send_lowpriority(ctx, id, buffer, sz);
-	return 0;
+	int err = skynet_socket_send_lowpriority(ctx, id, buffer, sz);
+	lua_pushboolean(L, !err);
+	return 1;
 }
 
 static int
@@ -593,6 +594,14 @@ lnodelay(lua_State *L) {
 	struct skynet_context * ctx = lua_touserdata(L, lua_upvalueindex(1));
 	int id = luaL_checkinteger(L, 1);
 	skynet_socket_nodelay(ctx,id);
+	return 0;
+}
+static int
+lwarnsize(lua_State *L) {
+	struct skynet_context * ctx = lua_touserdata(L, lua_upvalueindex(1));
+	int id = luaL_checkinteger(L, 1);
+	int sz = luaL_checkinteger(L, 2);
+	skynet_socket_warnsize(ctx,id,sz);
 	return 0;
 }
 
@@ -644,9 +653,7 @@ ludp_send(lua_State *L) {
 	int sz = 0;
 	void *buffer = get_buffer(L, 3, &sz);
 	int err = skynet_socket_udp_send(ctx, id, address, buffer, sz);
-
 	lua_pushboolean(L, !err);
-
 	return 1;
 }
 
@@ -704,6 +711,7 @@ luaopen_socketdriver(lua_State *L) {
 		{ "bind", lbind },
 		{ "start", lstart },
 		{ "nodelay", lnodelay },
+		{ "warnsize", lwarnsize},
 		{ "udp", ludp },
 		{ "udp_connect", ludp_connect },
 		{ "udp_send", ludp_send },

--- a/lualib/snax/gateserver.lua
+++ b/lualib/snax/gateserver.lua
@@ -113,7 +113,7 @@ function gateserver.start(handler)
 	function MSG.error(fd, msg)
 		if fd == socket then
 			socketdriver.close(fd)
-			skynet.error(msg)
+			skynet.error("gateserver close listen socket, accpet error:",msg)
 		else
 			if handler.error then
 				handler.error(fd, msg)
@@ -127,6 +127,12 @@ function gateserver.start(handler)
 			handler.warning(fd, size)
 		end
 	end
+	
+	function MSG.empty(fd)
+        	if handler.empty then
+            		handler.empty(fd) 
+        	end 
+    	end
 
 	skynet.register_protocol {
 		name = "socket",

--- a/lualib/socketchannel.lua
+++ b/lualib/socketchannel.lua
@@ -383,16 +383,23 @@ function channel:request(request, response, padding)
 	if padding then
 		-- padding may be a table, to support multi part request
 		-- multi part request use low priority socket write
-		-- socket_lwrite returns nothing
-		socket_lwrite(fd , request)
+		-- now socket_lwrite returns as socket_write
+        local function sock_err()
+		close_channel_socket(self)
+		wakeup_all(self)
+		error(socket_error)
+        end
+		if not socket_lwrite(fd , request) then
+		sock_err()
+        	end
 		for _,v in ipairs(padding) do
-			socket_lwrite(fd, v)
+			if not socket_lwrite(fd, v) then
+				sock_err()
+			end
 		end
 	else
 		if not socket_write(fd , request) then
-			close_channel_socket(self)
-			wakeup_all(self)
-			error(socket_error)
+			sock_err()
 		end
 	end
 

--- a/service-src/service_harbor.c
+++ b/service-src/service_harbor.c
@@ -681,6 +681,8 @@ mainloop(struct skynet_context * context, void * ud, int type, int session, uint
 			}
 			break;
 		}
+		case SKYNET_SOCKET_TYPE_EMPTY:
+			break;
 		default:
 			skynet_error(context, "recv invalid socket message type %d", type);
 			break;

--- a/service/gate.lua
+++ b/service/gate.lua
@@ -67,6 +67,10 @@ function handler.warning(fd, size)
 	skynet.send(watchdog, "lua", "socket", "warning", fd, size)
 end
 
+function handler.empty(fd, size)
+	skynet.send(watchdog, "lua", "socket", "empty", fd, size)
+end
+
 local CMD = {}
 
 function CMD.forward(source, fd, client, address)

--- a/skynet-src/skynet_socket.h
+++ b/skynet-src/skynet_socket.h
@@ -10,6 +10,7 @@ struct skynet_context;
 #define SKYNET_SOCKET_TYPE_ERROR 5
 #define SKYNET_SOCKET_TYPE_UDP 6
 #define SKYNET_SOCKET_TYPE_WARNING 7
+#define SKYNET_SOCKET_TYPE_EMPTY 8
 
 struct skynet_socket_message {
 	int type;
@@ -24,7 +25,7 @@ void skynet_socket_free();
 int skynet_socket_poll();
 
 int skynet_socket_send(struct skynet_context *ctx, int id, void *buffer, int sz);
-void skynet_socket_send_lowpriority(struct skynet_context *ctx, int id, void *buffer, int sz);
+int skynet_socket_send_lowpriority(struct skynet_context *ctx, int id, void *buffer, int sz);
 int skynet_socket_listen(struct skynet_context *ctx, const char *host, int port, int backlog);
 int skynet_socket_connect(struct skynet_context *ctx, const char *host, int port);
 int skynet_socket_bind(struct skynet_context *ctx, int fd);
@@ -32,6 +33,7 @@ void skynet_socket_close(struct skynet_context *ctx, int id);
 void skynet_socket_shutdown(struct skynet_context *ctx, int id);
 void skynet_socket_start(struct skynet_context *ctx, int id);
 void skynet_socket_nodelay(struct skynet_context *ctx, int id);
+void skynet_socket_warnsize(struct skynet_context *ctx, int id, int warnsz);
 
 int skynet_socket_udp(struct skynet_context *ctx, const char * addr, int port);
 int skynet_socket_udp_connect(struct skynet_context *ctx, int id, const char * addr, int port);

--- a/skynet-src/socket_server.h
+++ b/skynet-src/socket_server.h
@@ -10,6 +10,8 @@
 #define SOCKET_ERR 4
 #define SOCKET_EXIT 5
 #define SOCKET_UDP 6
+#define SOCKET_WARNING 7
+#define SOCKET_EMPTY 8
 
 struct socket_server;
 
@@ -30,8 +32,8 @@ void socket_server_shutdown(struct socket_server *, uintptr_t opaque, int id);
 void socket_server_start(struct socket_server *, uintptr_t opaque, int id);
 
 // return -1 when error
-int64_t socket_server_send(struct socket_server *, int id, const void * buffer, int sz);
-void socket_server_send_lowpriority(struct socket_server *, int id, const void * buffer, int sz);
+int socket_server_send(struct socket_server *, int id, const void * buffer, int sz);
+int socket_server_send_lowpriority(struct socket_server *, int id, const void * buffer, int sz);
 
 // ctrl command below returns id
 int socket_server_listen(struct socket_server *, uintptr_t opaque, const char * addr, int port, int backlog);
@@ -40,6 +42,9 @@ int socket_server_bind(struct socket_server *, uintptr_t opaque, int fd);
 
 // for tcp
 void socket_server_nodelay(struct socket_server *, int id);
+
+//param warnsz unit KB, set negative to close warning
+void socket_server_warnsize(struct socket_server *, int id, int warnsz);
 
 struct socket_udp_address;
 
@@ -50,7 +55,7 @@ int socket_server_udp(struct socket_server *, uintptr_t opaque, const char * add
 int socket_server_udp_connect(struct socket_server *, int id, const char * addr, int port);
 // If the socket_udp_address is NULL, use last call socket_server_udp_connect address instead
 // You can also use socket_server_send 
-int64_t socket_server_udp_send(struct socket_server *, int id, const struct socket_udp_address *, const void *buffer, int sz);
+int socket_server_udp_send(struct socket_server *, int id, const struct socket_udp_address *, const void *buffer, int sz);
 // extract the address of the message, struct socket_message * should be SOCKET_UDP
 const struct socket_udp_address * socket_server_udp_address(struct socket_server *, struct socket_message *, int *addrsz);
 


### PR DESCRIPTION
做一些重IO的应用，虽然有SOCKET_WARNING消息，单没有对应的empty消息通知，比如default_warning中warnsize增大后无法回归为0，所以对socket做了点修改，兼容原API，增强控制，：
增加SOCKET_EMPTY消息，在缓存队列清空时激发； 同时SOCKET_WARNING的判断移到IO线程中；socket发送api返回值现在都是-1失败，0成功。
socket.lua中socket.warning(id, callback, warnsz)第三个参数 wansz单位KB，设置缓存警戒线，-1关闭警告，同时也不会有SOCKE_EMPTY消息；对应empty增加socket.empty(id, callback)。
原来send_buffer()中的step4，在低优先队列不为空时会多一次可写事件判断，已修改。
