### PR TITLE
optimize SOCKET_WARNING msg

### DIFF
--- a/lualib-src/lua-socket.c
+++ b/lualib-src/lua-socket.c
@@ -567,8 +567,9 @@ lsendlow(lua_State *L) {
 	int id = luaL_checkinteger(L, 1);
 	int sz = 0;
 	void *buffer = get_buffer(L, 2, &sz);
-	skynet_socket_send_lowpriority(ctx, id, buffer, sz);
-	return 0;
+	int err = skynet_socket_send_lowpriority(ctx, id, buffer, sz);
+	lua_pushboolean(L, !err);
+	return 1;
 }
 
 static int

--- a/lualib/snax/gateserver.lua
+++ b/lualib/snax/gateserver.lua
@@ -113,7 +113,7 @@ function gateserver.start(handler)
 	function MSG.error(fd, msg)
 		if fd == socket then
 			socketdriver.close(fd)
-			skynet.error(msg)
+			skynet.error("gateserver close listen socket, accpet error:",msg)
 		else
 			if handler.error then
 				handler.error(fd, msg)

--- a/lualib/socket.lua
+++ b/lualib/socket.lua
@@ -138,19 +138,17 @@ end
 
 local function default_warning(id, size)
 	local s = socket_pool[id]
-		local last = s.warningsize or 0
-		if last + 64 < size then	-- if size increase 64K
-			s.warningsize = size
-			skynet.error(string.format("WARNING: %d K bytes need to send out (fd = %d)", size, id))
-		end
-		s.warningsize = size
+	if not s then
+		return
+	end
+	skynet.error(string.format("WARNING: %d K bytes need to send out (fd = %d)", size, id))
 end
 
 -- SKYNET_SOCKET_TYPE_WARNING
 socket_message[7] = function(id, size)
 	local s = socket_pool[id]
 	if s then
-		local warning = s.warning or default_warning
+		local warning = s.on_warning or default_warning
 		warning(id, size)
 	end
 end
@@ -442,7 +440,7 @@ socket.udp_address = assert(driver.udp_address)
 function socket.warning(id, callback)
 	local obj = socket_pool[id]
 	assert(obj)
-	obj.warning = callback
+	obj.on_warning = callback
 end
 
 return socket

--- a/lualib/socketchannel.lua
+++ b/lualib/socketchannel.lua
@@ -383,16 +383,23 @@ function channel:request(request, response, padding)
 	if padding then
 		-- padding may be a table, to support multi part request
 		-- multi part request use low priority socket write
-		-- socket_lwrite returns nothing
-		socket_lwrite(fd , request)
-		for _,v in ipairs(padding) do
-			socket_lwrite(fd, v)
-		end
-	else
-		if not socket_write(fd , request) then
+		-- now socket_lwrite returns as socket_write
+		local function sock_err()
 			close_channel_socket(self)
 			wakeup_all(self)
 			error(socket_error)
+		end
+		if not socket_lwrite(fd , request) then
+			sock_err()
+		end
+		for _,v in ipairs(padding) do
+			if not socket_lwrite(fd, v) then
+				sock_err()
+			end
+		end
+	else
+		if not socket_write(fd , request) then
+			sock_err()
 		end
 	end
 

--- a/skynet-src/skynet_socket.c
+++ b/skynet-src/skynet_socket.c
@@ -98,6 +98,9 @@ skynet_socket_poll() {
 	case SOCKET_UDP:
 		forward_message(SKYNET_SOCKET_TYPE_UDP, false, &result);
 		break;
+	case SOCKET_WARNING:
+		forward_message(SKYNET_SOCKET_TYPE_WARNING, false, &result);
+		break;
 	default:
 		skynet_error(NULL, "Unknown socket message type %d.",type);
 		return -1;
@@ -108,31 +111,14 @@ skynet_socket_poll() {
 	return 1;
 }
 
-static int
-check_wsz(struct skynet_context *ctx, int id, void *buffer, int64_t wsz) {
-	if (wsz < 0) {
-		return -1;
-	} else if (wsz > 1024 * 1024) {
-		struct skynet_socket_message tmp;
-		tmp.type = SKYNET_SOCKET_TYPE_WARNING;
-		tmp.id = id;
-		tmp.ud = (int)(wsz / 1024);
-		tmp.buffer = NULL;
-		skynet_send(ctx, 0, skynet_context_handle(ctx), PTYPE_SOCKET, 0 , &tmp, sizeof(tmp));
-//		skynet_error(ctx, "%d Mb bytes on socket %d need to send out", (int)(wsz / (1024 * 1024)), id);
-	}
-	return 0;
+int
+skynet_socket_send(struct skynet_context *ctx, int id, void *buffer, int sz) {
+	return socket_server_send(SOCKET_SERVER, id, buffer, sz);
 }
 
 int
-skynet_socket_send(struct skynet_context *ctx, int id, void *buffer, int sz) {
-	int64_t wsz = socket_server_send(SOCKET_SERVER, id, buffer, sz);
-	return check_wsz(ctx, id, buffer, wsz);
-}
-
-void
 skynet_socket_send_lowpriority(struct skynet_context *ctx, int id, void *buffer, int sz) {
-	socket_server_send_lowpriority(SOCKET_SERVER, id, buffer, sz);
+	return socket_server_send_lowpriority(SOCKET_SERVER, id, buffer, sz);
 }
 
 int 
@@ -189,8 +175,7 @@ skynet_socket_udp_connect(struct skynet_context *ctx, int id, const char * addr,
 
 int 
 skynet_socket_udp_send(struct skynet_context *ctx, int id, const char * address, const void *buffer, int sz) {
-	int64_t wsz = socket_server_udp_send(SOCKET_SERVER, id, (const struct socket_udp_address *)address, buffer, sz);
-	return check_wsz(ctx, id, (void *)buffer, wsz);
+	return socket_server_udp_send(SOCKET_SERVER, id, (const struct socket_udp_address *)address, buffer, sz);
 }
 
 const char *

--- a/skynet-src/skynet_socket.h
+++ b/skynet-src/skynet_socket.h
@@ -24,7 +24,7 @@ void skynet_socket_free();
 int skynet_socket_poll();
 
 int skynet_socket_send(struct skynet_context *ctx, int id, void *buffer, int sz);
-void skynet_socket_send_lowpriority(struct skynet_context *ctx, int id, void *buffer, int sz);
+int skynet_socket_send_lowpriority(struct skynet_context *ctx, int id, void *buffer, int sz);
 int skynet_socket_listen(struct skynet_context *ctx, const char *host, int port, int backlog);
 int skynet_socket_connect(struct skynet_context *ctx, const char *host, int port);
 int skynet_socket_bind(struct skynet_context *ctx, int fd);

--- a/skynet-src/socket_server.h
+++ b/skynet-src/socket_server.h
@@ -10,6 +10,7 @@
 #define SOCKET_ERR 4
 #define SOCKET_EXIT 5
 #define SOCKET_UDP 6
+#define SOCKET_WARNING 7
 
 struct socket_server;
 
@@ -30,8 +31,8 @@ void socket_server_shutdown(struct socket_server *, uintptr_t opaque, int id);
 void socket_server_start(struct socket_server *, uintptr_t opaque, int id);
 
 // return -1 when error
-int64_t socket_server_send(struct socket_server *, int id, const void * buffer, int sz);
-void socket_server_send_lowpriority(struct socket_server *, int id, const void * buffer, int sz);
+int socket_server_send(struct socket_server *, int id, const void * buffer, int sz);
+int socket_server_send_lowpriority(struct socket_server *, int id, const void * buffer, int sz);
 
 // ctrl command below returns id
 int socket_server_listen(struct socket_server *, uintptr_t opaque, const char * addr, int port, int backlog);
@@ -50,7 +51,7 @@ int socket_server_udp(struct socket_server *, uintptr_t opaque, const char * add
 int socket_server_udp_connect(struct socket_server *, int id, const char * addr, int port);
 // If the socket_udp_address is NULL, use last call socket_server_udp_connect address instead
 // You can also use socket_server_send 
-int64_t socket_server_udp_send(struct socket_server *, int id, const struct socket_udp_address *, const void *buffer, int sz);
+int socket_server_udp_send(struct socket_server *, int id, const struct socket_udp_address *, const void *buffer, int sz);
 // extract the address of the message, struct socket_message * should be SOCKET_UDP
 const struct socket_udp_address * socket_server_udp_address(struct socket_server *, struct socket_message *, int *addrsz);
 


### PR DESCRIPTION
优化了SOCKET_WARNING机制，超过1M后会在缓存每翻一倍时发送一次waring警告消息 ，之后在缓存又降为0时发送warning 0KB 的消息。
socket发送api返回值现在都是-1失败，0成功。
虚拟机测试时发现sp_wait可能有EINTR错误，添加了处理。
原来send_buffer()中的step4，在低优先队列不为空时会多一次sp_wait可写事件判断，已修改。