### PR TITLE
hook memalign

### DIFF
--- a/skynet-src/malloc_hook.c
+++ b/skynet-src/malloc_hook.c
@@ -195,6 +195,13 @@ skynet_calloc(size_t nmemb,size_t size) {
 	return fill_prefix(ptr);
 }
 
+void *
+skynet_memalign(size_t alignment, size_t size) {
+	void* ptr = je_memalign(alignment, size + PREFIX_SIZE);
+	if(!ptr) malloc_oom(size);
+	return fill_prefix(ptr);
+}
+
 #else
 
 // for skynet_lalloc use

--- a/skynet-src/skynet_malloc.h
+++ b/skynet-src/skynet_malloc.h
@@ -7,6 +7,7 @@
 #define skynet_calloc calloc
 #define skynet_realloc realloc
 #define skynet_free free
+#define skynet_memalign memalign
 
 void * skynet_malloc(size_t sz);
 void * skynet_calloc(size_t nmemb,size_t size);
@@ -14,5 +15,6 @@ void * skynet_realloc(void *ptr, size_t size);
 void skynet_free(void *ptr);
 char * skynet_strdup(const char *str);
 void * skynet_lalloc(void *ptr, size_t osize, size_t nsize);	// use for lua
+void * skynet_memalign(size_t alignment, size_t size);
 
 #endif


### PR DESCRIPTION
项目中引入使用 cryptopp 库出现崩溃
崩溃原因是 cryptopp 中部分内存使用了 memalign 进行分配，而 skynet 没有 hook 该函数，导致在释放这部分内存时出现越界访问导致程序崩溃
建议将 memalign 加入 malloc hook