### PR TITLE
更正connection丢失的问题

### DIFF
--- a/lualib/skynet/db/redis/cluster.lua
+++ b/lualib/skynet/db/redis/cluster.lua
@@ -33,7 +33,7 @@ function _M.new(startup_nodes,opt)
 end
 
 local function nodename(node)
-	return string.format("%s:%s",node.host,node.port)
+	return string.format("%s:%d",node.host,node.port)
 end
 
 function rediscluster:get_redis_link(node)


### PR DESCRIPTION
根据test文件中，输入端口号为number类型，此处应该使用d%，否则只format直进来ip，容易造成同一个ip地址的connection丢失。