### PR TITLE
Fix double free

### DIFF
--- a/service-src/service_harbor.c
+++ b/service-src/service_harbor.c
@@ -421,6 +421,7 @@ push_socket_data(struct harbor *h, const struct skynet_socket_message * message)
 	}
 	if (s == NULL) {
 		skynet_free(message->buffer);
+		((struct skynet_socket_message *)message)->buffer = NULL;
 		skynet_error(h->ctx, "Invalid socket fd (%d) data", fd);
 		return;
 	}


### PR DESCRIPTION
In the mainloop function, calling __skynet_free__ frees the pointer which may has already been freed in __push_socket_data__.

mainloop(struct skynet_context * context, void * ud, int type, int session, uint32_t source, const void * msg, size_t sz) {
        struct harbor * h = ud;
        switch (type) {
        case PTYPE_SOCKET: {
                const struct skynet_socket_message * message = msg;
                switch(message->type) {
                case SKYNET_SOCKET_TYPE_DATA:
                        push_socket_data(h, message);
                        skynet_free(message->buffer);
                        // skip...

To fix this potential double-free bug, clear the pointer message->buffer in __push_socket_data__ after the pointer is freed.