### PR TITLE
Fix fd leak

### DIFF
--- a/skynet-src/skynet_daemon.c
+++ b/skynet-src/skynet_daemon.c
@@ -39,6 +39,7 @@ write_pid(const char *pidfile) {
 	}
 	f = fdopen(fd, "r+");
 	if (f == NULL) {
+		close(fd);
 		fprintf(stderr, "Can't open pidfile [%s].\n", pidfile);
 		return 0;
 	}
@@ -57,10 +58,10 @@ write_pid(const char *pidfile) {
 	pid = getpid();
 	if (!fprintf(f,"%d\n", pid)) {
 		fprintf(stderr, "Can't write pid.\n");
-		close(fd);
+		fclose(f);
 		return 0;
 	}
-	fflush(f);
+	fclose(f);
 
 	return pid;
 }


### PR DESCRIPTION
Even though only one file descriptor is created in __write_pid__ through __daemon_init__ (ONCE),
it would be better to free the file descriptor.

Call __fclose__ to flush the buffer and close the corresponding file descriptor on exit of __write_pid__.