### PR TITLE
Properly initialize sigaction struct

### DIFF
--- a/skynet-src/skynet_main.c
+++ b/skynet-src/skynet_main.c
@@ -78,6 +78,8 @@ _init_env(lua_State *L) {
 int sigign() {
 	struct sigaction sa;
 	sa.sa_handler = SIG_IGN;
+	sa.sa_flags = 0;
+	sigemptyset(&sa.sa_mask);
 	sigaction(SIGPIPE, &sa, 0);
 	return 0;
 }


### PR DESCRIPTION
The code in skynet_main.c wasn't clearing the struct sigaction before passing it to sigaction().
This meant that we would block a random set of signals while executing the SIGPIPE handler, or jump to the uninitialized __sa_sigaction__ (instead of sa_handler).
Initialize properly as we do in skynet_start.c.