### PR TITLE
add ipv6 host support to service_gate.c

### DIFF
--- a/service-src/service_gate.c
+++ b/service-src/service_gate.c
@@ -313,7 +313,7 @@ _cb(struct skynet_context * ctx, void * ud, int type, int session, uint32_t sour
 static int
 start_listen(struct gate *g, char * listen_addr) {
 	struct skynet_context * ctx = g->ctx;
-	char * portstr = strchr(listen_addr,':');
+	char * portstr = strrchr(listen_addr,':');
 	const char * host = "";
 	int port;
 	if (portstr == NULL) {


### PR DESCRIPTION
service_gate的地址解析用strchr找到第一个':'，并将后续的字符串作为
端口号解析。填ipv6地址"0:0:0:0:0:0:0:0:9999"的时候会出错，现在改成
strrchr，从右面找到的第一个':'