### PR TITLE
set backlog to 128

### DIFF
--- a/service-src/service_gate.c
+++ b/service-src/service_gate.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-#define BACKLOG 32
+#define BACKLOG 128
 
 struct connection {
 	int id;	// skynet_socket id


### PR DESCRIPTION
单机16核32G，pps 50w，压测 5w 连接，上来只简单的发 ping 包，不能顺利创建 5w 连接，客户端会出现少量连接超时。backlog 改成 128 后，可以顺利创建 5w 连接。
具体原因仍在排查，但是改为 128 应该是个较普遍的值。