### PR TITLE
fix kqueue eof event

### DIFF
--- a/skynet-src/socket_epoll.h
+++ b/skynet-src/socket_epoll.h
@@ -60,6 +60,7 @@ sp_wait(int efd, struct event *e, int max) {
 		e[i].write = (flag & EPOLLOUT) != 0;
 		e[i].read = (flag & (EPOLLIN | EPOLLHUP)) != 0;
 		e[i].error = (flag & EPOLLERR) != 0;
+		e[i].eof = false;
 	}
 
 	return n;

--- a/skynet-src/socket_kqueue.h
+++ b/skynet-src/socket_kqueue.h
@@ -73,9 +73,11 @@ sp_wait(int kfd, struct event *e, int max) {
 	for (i=0;i<n;i++) {
 		e[i].s = ev[i].udata;
 		unsigned filter = ev[i].filter;
-		e[i].write = (filter == EVFILT_WRITE);
-		e[i].read = (filter == EVFILT_READ);
+		bool eof = (ev[i].flags & EV_EOF) != 0;
+		e[i].write = (filter == EVFILT_WRITE) && (!eof);
+		e[i].read = (filter == EVFILT_READ) && (!eof);
 		e[i].error = false;	// kevent has not error event
+		e[i].eof = eof;
 	}
 
 	return n;

--- a/skynet-src/socket_poll.h
+++ b/skynet-src/socket_poll.h
@@ -10,6 +10,7 @@ struct event {
 	bool read;
 	bool write;
 	bool error;
+	bool eof;
 };
 
 static bool sp_invalid(poll_fd fd);

--- a/skynet-src/socket_server.c
+++ b/skynet-src/socket_server.c
@@ -1461,6 +1461,10 @@ socket_server_poll(struct socket_server *ss, struct socket_message * result, int
 				result->data = (char *)err;
 				return SOCKET_ERR;
 			}
+			if(e->eof) {
+				force_close(ss, s, &l, result);
+				return SOCKET_CLOSE;
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
在macosx上面socket断开连接，调用read接口有概率会返回`RST`错误。根据kqueue手册 [kqueue event](https://www.freebsd.org/cgi/man.cgi?kqueue)
```
If the read direction of the socket has shutdown,
then the filter also sets EV_EOF in flags,	and
returns the socket	error (if any) in fflags.  It
is possible for EOF to be returned	(indicating
the connection is gone) while there is still data
pending in the socket buffer.
```
当socket关闭时，kqueue会写`EOF`flag，所以需要对kqueue的event 添加`EOF`flag，从而关闭关闭socket.
参考实例： [kqueue tutorial](https://wiki.netbsd.org/tutorials/kqueue_tutorial/)
PS: 此问题只会在kqueue上面才会出现， epoll并不会有问题。
