### PR TITLE
queryname并发导致消息乱序

### DIFF
--- a/service/clusteragent.lua
+++ b/service/clusteragent.lua
@@ -17,7 +17,7 @@ setmetatable(register_name, { __index =
 	function(self, name)
 		local waitco = inquery_name[name]
 		if waitco then
-			local co=coroutine.runnging()
+			local co=coroutine.running()
 			table.insert(waitco, co)
 			skynet.wait(co)
 			return rawget(self, name)


### PR DESCRIPTION
当有1个以上的co进入queryname,后面的协程有可能在未返回的co之前执行（第一个已经返回），导致cluster消息乱序