### PR TITLE
增加以服务名为参数的call命令

### DIFF
--- a/service/debug_console.lua
+++ b/service/debug_console.lua
@@ -360,20 +360,24 @@ function COMMAND.trace(address, proto, flag)
 	skynet.call(address, "debug", "TRACELOG", proto, flag)
 end
 
-function COMMANDX.call(cmd)
-	local address = adjust_address(cmd[2])
+local function call(address, cmd)
 	local cmdline = assert(cmd[1]:match("%S+%s+%S+%s(.+)") , "need arguments")
 	local args_func = assert(load("return " .. cmdline, "debug console", "t", {}), "Invalid arguments")
 	local args = table.pack(pcall(args_func))
 	if not args[1] then
 		error(args[2])
 	end
+
 	local rets = table.pack(skynet.call(address, "lua", table.unpack(args, 2, args.n)))
 	return rets
 end
 
+function COMMANDX.call(cmd)
+	local address = adjust_address(cmd[2])
+	return call(address, cmd)
+end
+
 function COMMANDX.callname(cmd)
 	local name = cmd[2]
-	local rets = skynet.call(name, "lua", cmd[3] )
-	return rets
+	return call(name, cmd)
 end

--- a/service/debug_console.lua
+++ b/service/debug_console.lua
@@ -69,7 +69,7 @@ local function docmd(cmdline, print, fd)
 			split[1] = cmdline
 			ok, list = pcall(cmd, split)
 		else
-			print("Invalid command, type help for command list")
+			print("Invalid command, type help for command list " .. command)
 		end
 	end
 
@@ -369,5 +369,11 @@ function COMMANDX.call(cmd)
 		error(args[2])
 	end
 	local rets = table.pack(skynet.call(address, "lua", table.unpack(args, 2, args.n)))
+	return rets
+end
+
+function COMMANDX.callname(cmd)
+	local name = cmd[2]
+	local rets = skynet.call(name, "lua", cmd[3] )
 	return rets
 end


### PR DESCRIPTION
有时候 需要在 执行 关服操作时 以 服务名 为参数的调用
去执行 事先 不知道服务地址的情况