### PR TITLE
output to stdout without logger service

### DIFF
--- a/skynet-src/skynet_error.c
+++ b/skynet-src/skynet_error.c
@@ -17,6 +17,14 @@ skynet_error(struct skynet_context * context, const char *msg, ...) {
 		logger = skynet_handle_findname("logger");
 	}
 	if (logger == 0) {
+		int source = skynet_context_handle(context);
+		printf("[:%08x] ",source);
+		va_list ap;
+		va_start(ap,msg);
+		vprintf(msg, ap);
+		va_end(ap);
+		printf("\n");
+		fflush(stdout);
 		return;
 	}
 


### PR DESCRIPTION
自定义lua服务logger的时候，启动需要一点时间，期间的日志是丢失的，建议在找不到logger服务的时候，能将skynet内部日志输出到stdout。