### PR TITLE
dns reInit bug

### DIFF
--- a/test/testhttp.lua
+++ b/test/testhttp.lua
@@ -3,7 +3,7 @@ local httpc = require "http.httpc"
 local dns = require "skynet.dns"
 
 local function main()
-	httpc.dns()	-- set dns server
+	--httpc.dns()	-- set dns server
 	httpc.timeout = 100	-- set timeout 1 second
 	print("GET baidu.com")
 	local respheader = {}


### PR DESCRIPTION
**recall dns.server()**
_false	./lualib/skynet/dns.lua:340: assertion failed!_