### PR TITLE
修改pid打开方式为w+

### DIFF
--- a/skynet-src/skynet_daemon.c
+++ b/skynet-src/skynet_daemon.c
@@ -36,7 +36,7 @@ write_pid(const char *pidfile) {
 		fprintf(stderr, "Can't create %s.\n", pidfile);
 		return 0;
 	}
-	f = fdopen(fd, "r+");
+	f = fdopen(fd, "w+");
 	if (f == NULL) {
 		fprintf(stderr, "Can't open %s.\n", pidfile);
 		return 0;


### PR DESCRIPTION
目前使用r+打开，如果旧的pid比新的pid长，会导致有残留的数字在pid文件中。