### PR TITLE
fix check header limit

### DIFF
--- a/lualib/http/internal.lua
+++ b/lualib/http/internal.lua
@@ -48,9 +48,6 @@ function M.recvheader(readbytes, lines, header)
 		while true do
 			local bytes = readbytes()
 			header = header .. bytes
-			if #header > LIMIT then
-				return
-			end
 			e = header:find("\r\n\r\n", -#bytes-3, true)
 			if e then
 				result = header:sub(e+4)
@@ -58,6 +55,9 @@ function M.recvheader(readbytes, lines, header)
 			end
 			if header:find "^\r\n" then
 				return header:sub(3)
+			end
+			if #header > LIMIT then
+				return
 			end
 		end
 	end


### PR DESCRIPTION
调整了判断 http header的判断长度时机，对于请求的数据比较大的情况(`readbytes`返回包含了正常的header和body)，由于优先判断了`LIMIT`导致正常请求也被判断为攻击，抛出`[socket error]`; 所以调整了判断`LIMIT`的顺序。