### PR TITLE
去掉dbgcmd.RUN的gc

### DIFF
--- a/lualib/skynet/debug.lua
+++ b/lualib/skynet/debug.lua
@@ -58,7 +58,6 @@ local function init(skynet, export)
 			local inject = require "skynet.inject"
 			local args = table.pack(...)
 			local ok, output = inject(skynet, source, filename, args, export.dispatch, skynet.register_protocol)
-			collectgarbage "collect"
 			skynet.ret(skynet.pack(ok, table.concat(output, "\n")))
 		end
 


### PR DESCRIPTION
线上运行的过程中通过debug热更代码，gc会导致服务器卡顿。