### PR TITLE
bugfix:cluster初始化节点的时候有可能导致消息乱序

### DIFF
--- a/lualib/skynet/cluster.lua
+++ b/lualib/skynet/cluster.lua
@@ -11,16 +11,19 @@ local function get_sender(t, node)
 		local co=coroutine.running()
 		table.insert(waitco, co)
 		skynet.wait(co)
-		return rawget(t, node)
+		return assert(rawget(t, node))
 	else
 		waitco = {}
 		inquery_name[node] = waitco
-		local c = skynet.call(clusterd, "lua", "sender", node)
+		local ok,c = pcall(skynet.call, clusterd, "lua", "sender", node)
+		if ok then
+			t[node] = c
+		end
 		inquery_name[node] = nil
-		t[node] = c
 		for _, co in ipairs(waitco) do
 			skynet.wakeup(co)
 		end
+		assert(ok,c)
 		return c
 	end
 end

--- a/lualib/skynet/cluster.lua
+++ b/lualib/skynet/cluster.lua
@@ -3,11 +3,26 @@ local skynet = require "skynet"
 local clusterd
 local cluster = {}
 local sender = {}
+local inquery_name = {}
 
 local function get_sender(t, node)
-	local c = skynet.call(clusterd, "lua", "sender", node)
-	t[node] = c
-	return c
+	local waitco = inquery_name[node]
+	if waitco then
+		local co=coroutine.running()
+		table.insert(waitco, co)
+		skynet.wait(co)
+		return rawget(t, node)
+	else
+		waitco = {}
+		inquery_name[node] = waitco
+		local c = skynet.call(clusterd, "lua", "sender", node)
+		inquery_name[node] = nil
+		t[node] = c
+		for _, co in ipairs(waitco) do
+			skynet.wakeup(co)
+		end
+		return c
+	end
 end
 
 setmetatable(sender, { __index = get_sender } )


### PR DESCRIPTION
类似#870

这样的修改有个额外的问题，send有可能抛出异常（之前的send不会）