### PR TITLE
Revert "bugfix:cluster初始化节点的时候有可能导致消息乱序"

### DIFF
--- a/lualib/skynet/cluster.lua
+++ b/lualib/skynet/cluster.lua
@@ -3,26 +3,11 @@ local skynet = require "skynet"
 local clusterd
 local cluster = {}
 local sender = {}
-local inquery_name = {}
 
 local function get_sender(t, node)
-	local waitco = inquery_name[node]
-	if waitco then
-		local co=coroutine.running()
-		table.insert(waitco, co)
-		skynet.wait(co)
-		return rawget(t, node)
-	else
-		waitco = {}
-		inquery_name[node] = waitco
-		local c = skynet.call(clusterd, "lua", "sender", node)
-		inquery_name[node] = nil
-		t[node] = c
-		for _, co in ipairs(waitco) do
-			skynet.wakeup(co)
-		end
-		return c
-	end
+	local c = skynet.call(clusterd, "lua", "sender", node)
+	t[node] = c
+	return c
 end
 
 setmetatable(sender, { __index = get_sender } )

--- a/lualib/skynet/cluster.lua
+++ b/lualib/skynet/cluster.lua
@@ -11,19 +11,16 @@ local function get_sender(t, node)
 		local co=coroutine.running()
 		table.insert(waitco, co)
 		skynet.wait(co)
-		return assert(rawget(t, node))
+		return rawget(t, node)
 	else
 		waitco = {}
 		inquery_name[node] = waitco
-		local ok,c = pcall(skynet.call, clusterd, "lua", "sender", node)
-		if ok then
-			t[node] = c
-		end
+		local c = skynet.call(clusterd, "lua", "sender", node)
 		inquery_name[node] = nil
+		t[node] = c
 		for _, co in ipairs(waitco) do
 			skynet.wakeup(co)
 		end
-		assert(ok,c)
 		return c
 	end
 end


### PR DESCRIPTION
Reverts cloudwu/skynet#988