### PR TITLE
collectgarbage count change to lua 5.3

### DIFF
--- a/lualib/skynet/debug.lua
+++ b/lualib/skynet/debug.lua
@@ -14,8 +14,8 @@ local function init(skynet, export)
 		dbgcmd = {}
 
 		function dbgcmd.MEM()
-			local kb, bytes = collectgarbage "count"
-			skynet.ret(skynet.pack(kb,bytes))
+			local kb = collectgarbage "count"
+			skynet.ret(skynet.pack(kb))
 		end
 
 		function dbgcmd.GC()

--- a/service/launcher.lua
+++ b/service/launcher.lua
@@ -45,7 +45,7 @@ end
 function command.MEM()
 	local list = {}
 	for k,v in pairs(services) do
-		local ok, kb, bytes = pcall(skynet.call,k,"debug","MEM")
+		local ok, kb = pcall(skynet.call,k,"debug","MEM")
 		if not ok then
 			list[skynet.address(k)] = string.format("ERROR (%s)",v)
 		else


### PR DESCRIPTION
since lua 5.3, collectgarbage count did not return bytes:

The call collectgarbage("count") now returns only one result. (You can compute that second result from the fractional part of the first result.)

from https://www.lua.org/manual/5.2/manual.html#6.1:

"count": returns the total memory in use by Lua in Kbytes. The value has a fractional part, so that it multiplied by 1024 gives the exact number of bytes in use by Lua (except for overflows).
