### PR TITLE
build jemalloc with --enable-prof

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ $(JEMALLOC_STATICLIB) : 3rd/jemalloc/Makefile
 	git submodule update --init
 
 3rd/jemalloc/Makefile : | 3rd/jemalloc/autogen.sh
-	cd 3rd/jemalloc && ./autogen.sh --with-jemalloc-prefix=je_ --disable-valgrind
+	cd 3rd/jemalloc && ./autogen.sh --with-jemalloc-prefix=je_ --enable-prof
 
 jemalloc : $(MALLOC_STATICLIB)
 


### PR DESCRIPTION
1. Starting from jemalloc 5.0, valgrind integration has been removed. see [link](https://github.com/jemalloc/jemalloc/issues/369
)
2. Build jemalloc with --enable-prof has minimal overhead. see [link](https://github.com/jemalloc/jemalloc/issues/1496)

