### PR TITLE
fix use NOUSE_JEMALLOC

### DIFF
--- a/skynet-src/malloc_hook.c
+++ b/skynet-src/malloc_hook.c
@@ -257,6 +257,18 @@ mallctl_opt(const char* name, int* newval) {
 	return 0;
 }
 
+bool
+mallctl_bool(const char* name, bool* newval) {
+	skynet_error(NULL, "No jemalloc : mallctl_bool %s.", name);
+	return 0;
+}
+
+int
+mallctl_cmd(const char* name) {
+	skynet_error(NULL, "No jemalloc : mallctl_cmd %s.", name);
+	return 0;
+}
+
 #endif
 
 size_t


### PR DESCRIPTION
在macosx上面开启 `NOUSE_JEMALLOC`进行编译后运行会报错:
```
lua loader error : error loading module 'skynet.core' from file './luaclib/skynet.so':
	dlopen(./luaclib/skynet.so, 6): Symbol not found: _mallctl_cmd
  Referenced from: ./luaclib/skynet.so
  Expected in: flat namespace
 in ./luaclib/skynet.so
stack traceback:
	[C]: in ?
	[C]: in function 'require'
	./lualib/skynet.lua:2: in main chunk
	[C]: in function 'require'
	./service/bootstrap.lua:1: in local 'main'
	./lualib/loader.lua:48: in main chunk
```