### PR TITLE
#1014 fix kequeue eof when read

### DIFF
--- a/skynet-src/socket_kqueue.h
+++ b/skynet-src/socket_kqueue.h
@@ -75,7 +75,7 @@ sp_wait(int kfd, struct event *e, int max) {
 		unsigned filter = ev[i].filter;
 		bool eof = (ev[i].flags & EV_EOF) != 0;
 		e[i].write = (filter == EVFILT_WRITE) && (!eof);
-		e[i].read = (filter == EVFILT_READ) && (!eof);
+		e[i].read = (filter == EVFILT_READ);
 		e[i].error = (ev[i].flags & EV_ERROR) != 0;
 		e[i].eof = eof;
 	}


### PR DESCRIPTION
我这边打印了下， 确实会有可能`EV_EOF`和`EVFILT_READ`同时出现。测试用例很简单，就是用skynet中的`simpleweb.lua`作为简单的web服务，放在一台linux服务器上面。 之后再本地macosx上面用testhttp.lua`发起请求，很大概率会出现。

问题是，我记得早期是因为有了`EVFILT_READ`事件之后，如果当时还有`EV_EOF`flags的话调用`read`接口这个会拿到`RST`错误的。当时查了文档是说要优先判断`EV_EOF`。所以就加了优先判断`EV_EOF`。难道是新版本的macosx把这个问题当成bug给修复了？ Orz

我这边测试是没问题的， @keventan 你可以测试下，这个改法比较简单。;D