### PR TITLE
add sharetable update

### DIFF
--- a/lualib-src/lua-sharetable.c
+++ b/lualib-src/lua-sharetable.c
@@ -55,6 +55,17 @@ mark_shared(lua_State *L) {
 }
 
 static int
+lis_sharedtable(lua_State* L) {
+	int b = 0;
+	if(lua_type(L, 1) == LUA_TTABLE) {
+		Table * t = (Table *)lua_topointer(L, 1);
+		b = isshared(t);
+	}
+	lua_pushboolean(L, b);
+	return 1;
+}
+
+static int
 make_matrix(lua_State *L) {
 	// turn off gc , because marking shared will prevent gc mark.
 	lua_gc(L, LUA_GCSTOP, 0);
@@ -212,6 +223,7 @@ luaopen_skynet_sharetable_core(lua_State *L) {
 	luaL_Reg l[] = {
 		{ "clone", clone_table },
 		{ "matrix", matrix_from_file },
+		{ "is_sharedtable", lis_sharedtable },
 		{ NULL, NULL },
 	};
 	luaL_newlib(L, l);

--- a/lualib/skynet/sharetable.lua
+++ b/lualib/skynet/sharetable.lua
@@ -1,6 +1,7 @@
 local skynet = require "skynet"
 local service = require "skynet.service"
 local core = require "skynet.sharetable.core"
+local is_sharedtable = core.is_sharedtable
 
 local function sharetable_service()
 	local skynet = require "skynet"
@@ -218,6 +219,7 @@ local getupvalue = debug.getupvalue
 local setupvalue = debug.setupvalue
 local getlocal = debug.getlocal
 local setlocal = debug.setlocal
+local getinfo = debug.getinfo
 
 local NILOBJ = {}
 local function insert_replace(old_t, new_t, replace_map)
@@ -257,7 +259,7 @@ local function resolve_replace(replace_map)
         assert(v ~= nil)
         local tv = type(v)
         local f = match[tv]
-        if record_map[v] then
+        if record_map[v] or is_sharedtable(v) then
             return
         end
 
@@ -339,14 +341,14 @@ local function resolve_replace(replace_map)
     end
 
     local function match_function(f)
-        local info = debug.getinfo(f)
+        local info = getinfo(f, "uf")
         match_funcinfo(info)
     end
 
     local function match_thread(co)
         local level = 1
         while true do
-            local info = debug.getinfo(co, level)
+            local info = getinfo(co, level, "uf")
             if not info then
                 break
             end

--- a/lualib/skynet/sharetable.lua
+++ b/lualib/skynet/sharetable.lua
@@ -190,11 +190,201 @@ function sharetable.loadtable(filename, tbl)
 	skynet.call(sharetable.address, "lua", "loadtable", filename, skynet.pack(tbl))
 end
 
+
+local RECORD = {}
 function sharetable.query(filename)
 	local newptr = skynet.call(sharetable.address, "lua", "query", filename)
 	if newptr then
-		return core.clone(newptr)
+		local t = core.clone(newptr)
+		local map = RECORD[filename]
+		if not map then
+			map = {}
+			RECORD[filename] = map
+		end
+		map[t] = true
+		return t
 	end
+end
+
+
+local pairs = pairs
+local type = type
+local assert = assert
+local next = next
+local rawset = rawset
+local getuservalue = debug.getuservalue
+local setuservalue = debug.setuservalue
+local getupvalue = debug.getupvalue
+local setupvalue = debug.setupvalue
+local getlocal = debug.getlocal
+local setlocal = debug.setlocal
+
+local NILOBJ = {}
+local function insert_replace(old_t, new_t, replace_map)
+    for k, ov in pairs(old_t) do
+        if type(ov) == "table" then
+            local nv = new_t[k]
+            if nv == nil then
+                nv = NILOBJ
+            end
+            assert(replace_map[ov] == nil)
+            replace_map[ov] = nv
+            nv = type(nv) == "table" and nv or NILOBJ
+            insert_replace(ov, nv, replace_map)
+        end
+    end
+    replace_map[old_t] = new_t
+    return replace_map
+end
+
+
+local function resolve_replace(replace_map)
+    local match = {}
+    local record_map = {}
+
+    local function getnv(v)
+        local nv = replace_map[v]
+        if nv then
+            if nv == NILOBJ then
+                return nil
+            end
+            return nv
+        end
+        assert(false)
+    end
+
+    local function match_value(v)
+        assert(v ~= nil)
+        local tv = type(v)
+        local f = match[tv]
+        if record_map[v] then
+            return
+        end
+
+        if f then
+            record_map[v] = true
+            f(v)
+        end
+    end
+
+    local function match_mt(v)
+        local mt = getmetatable(v)
+        if mt then
+            local nv = replace_map[mt]
+            if nv then
+                nv = getnv(mt)
+                setmetatable(t, nv)
+            else
+                match_value(mt)
+            end
+        end
+    end
+
+    local function match_table(t)
+        for k,v in next, t do
+            local nv = replace_map[v]
+            if nv then
+                nv = getnv(v)
+                rawset(t, k, nv)
+            else
+                match_value(v)
+            end
+        end
+        match_mt(t)
+    end
+
+    local function match_userdata(u)
+        local uv = getuservalue(u)
+        local nv = replace_map[uv]
+        if nv then
+            nv = getnv(uv)
+            setuservalue(u, nv)
+        end
+        match_mt(u)
+    end
+
+    local function match_funcinfo(info)
+        local func = info.func
+        local nups = info.nups
+        for i=1,nups do
+            local name, upv = getupvalue(func, i)
+            local nv = replace_map[upv]
+            if nv then
+                nv = getnv(upv)
+                setupvalue(func, i, nv)
+            elseif upv then
+                match_value(upv)
+            end
+        end
+
+        local level = info.level
+        local curco = info.curco or coroutine.running()
+        if not level then
+            return
+        end
+        local i = 1
+        while true do
+            local name, v = getlocal(curco, level, i)
+            if name == nil then
+                break
+            end
+            if replace_map[v] then
+                local nv = getnv(v)
+                setlocal(curco, level, i, nv)
+            elseif v then
+                match_value(v)
+            end
+            i = i + 1
+        end
+    end
+
+    local function match_function(f)
+        local info = debug.getinfo(f)
+        match_funcinfo(info)
+    end
+
+    local function match_thread(co)
+        local level = 1
+        while true do
+            local info = debug.getinfo(co, level)
+            if not info then
+                break
+            end
+            info.level = level
+            info.curco = co
+            match_funcinfo(info)
+            level = level + 1
+        end
+    end
+
+    match["table"] = match_table
+    match["function"] = match_function
+    match["userdata"] = match_userdata
+    match["thread"] = match_thread
+
+    local root = debug.getregistry()
+    assert(replace_map[root] == nil)
+    match_table(root)
+end
+
+
+function sharetable.update(...)
+	local names = {...}
+	local replace_map = {}
+	for _, name in ipairs(names) do
+		local map = RECORD[name]
+		if map then
+			local new_t = sharetable.query(name)
+			for old_t,_ in pairs(map) do
+				if old_t ~= new_t then
+					insert_replace(old_t, new_t, replace_map)
+				end
+			end
+			RECORD[name] = nil
+		end
+	end
+
+	resolve_replace(replace_map)
 end
 
 return sharetable


### PR DESCRIPTION
对`sharetable`模块加了`update`接口，用来做热更新。 使用示例如下：
~~~.lua
 -- 在一个service中执行更新新的table
sharetable.loadfile("res", new_resource) 

-- 在需要更新的service中执行
sharetable.update("res")
~~~
`update`的实现是将新的`sharetable`和老的`sharetable`做对比， 生成一个`replace_map`，之后遍历整个vm进行替换所有的需要替换的`table`对象。