### PR TITLE
Websocket

### DIFF
--- a/lualib/http/websocket.lua
+++ b/lualib/http/websocket.lua
@@ -254,6 +254,7 @@ local function resolve_accept(self)
     local recv_buf = {}
     while true do
         if _isws_closed(self.id) then
+            try_handle(self, "close")
             return
         end
         local fin, op, payload_data = read_frame(self)
@@ -398,7 +399,9 @@ function M.accept(socket_id, handle, protocol)
     end
     if not ok then
         if err == socket_error then
-            if not closed then
+            if closed then
+                try_handle(ws_obj, "close")
+            else
                 try_handle(ws_obj, "error")
             end
         else


### PR DESCRIPTION
#1053  使用之前加的的`ltls`实现了websocket `ws`和`wss`协议。提供接口如下：

`websocket.accept(socket_id, handle, protocol)` 接受客户端`socket_id`发送过来的websocket协议。
`handle`为通知接口，`protocol`为`ws`和`wss`，默认为`ws`。

`websocket.connect(url, header)` 发起一个websocket连接，返回socket id。

`websocket.read(id)` 以websocket协议读取一个socket id。

`websocket.write(id, data, fmt)` 以websocket协议写入一个socket id。`data`为写入的内容，`fmt`为`text`或者`binary`。

`websocket.ping(id)` 以websocket协议发送ping frame。

`websocket.close(id, code, reason)` 以websocket协议关闭socket id，同时可选发送错误码`code`和错误原因`reason`。

具体的使用示例可以在`simplewebsocket.lua`代码中查看。
