### PR TITLE
add senders command in clusterd service

### DIFF
--- a/service/clusterd.lua
+++ b/service/clusterd.lua
@@ -135,6 +135,10 @@ function command.sender(source, node)
 	skynet.ret(skynet.pack(node_channel[node]))
 end
 
+function command.senders(source)
+	skynet.retpack(node_sender)
+end
+
 local proxy = {}
 
 function command.proxy(source, node, name)


### PR DESCRIPTION
在 kubernetes 集群中 socket 连接长期没有通信会被 IPVS 断开，断开时间是900s，远短于内核 Keep Alive 时间 2小时。该链接断开后，只有在下一次 write 时才会发现 Connection reset by peer，导致 Call failed。所以添加了一个接口，希望可以获取到节点内当前发生过通信的所有节点信息，以便进行健康监测。