### PR TITLE
match origin fucntion of thread

### DIFF
--- a/lualib-src/lua-sharetable.c
+++ b/lualib-src/lua-sharetable.c
@@ -83,6 +83,34 @@ clone_table(lua_State *L) {
 	return 1;
 }
 
+static int
+lco_stackvalues(lua_State* L) {
+    lua_State *cL = lua_tothread(L, 1);
+    luaL_argcheck(L, cL, 1, "thread expected");
+    int n = 0;
+    if(cL != L) {
+        luaL_checktype(L, 2, LUA_TTABLE);
+        n = lua_gettop(cL);
+        if(n > 0) {
+            lua_checkstack(L, n+1);
+            int top = lua_gettop(L);
+            lua_xmove(cL, L, n);
+            int i=0;
+            for(i=0; i<n; i++) {
+                lua_pushvalue(L, top+1+i);
+                lua_seti(L, 2, i+1);
+            }
+            lua_xmove(L, cL, n);
+        } else {
+            n = 0;
+        }
+    }
+
+    lua_pushinteger(L, n);
+    return 1;
+}
+
+
 struct state_ud {
 	lua_State *L;
 };
@@ -218,6 +246,7 @@ luaopen_skynet_sharetable_core(lua_State *L) {
 	luaL_checkversion(L);
 	luaL_Reg l[] = {
 		{ "clone", clone_table },
+		{ "stackvalues", lco_stackvalues }, 
 		{ "matrix", matrix_from_file },
 		{ "is_sharedtable", lis_sharedtable },
 		{ NULL, NULL },

--- a/lualib-src/lua-sharetable.c
+++ b/lualib-src/lua-sharetable.c
@@ -92,17 +92,15 @@ lco_stackvalues(lua_State* L) {
         luaL_checktype(L, 2, LUA_TTABLE);
         n = lua_gettop(cL);
         if(n > 0) {
-            lua_checkstack(L, n+1);
+            luaL_checkstack(L, n+1, NULL);
             int top = lua_gettop(L);
             lua_xmove(cL, L, n);
             int i=0;
-            for(i=0; i<n; i++) {
-                lua_pushvalue(L, top+1+i);
-                lua_seti(L, 2, i+1);
+            for(i=1; i<=n; i++) {
+                lua_pushvalue(L, top+i);
+                lua_seti(L, 2, i);
             }
             lua_xmove(L, cL, n);
-        } else {
-            n = 0;
         }
     }
 

--- a/lualib/skynet/sharetable.lua
+++ b/lualib/skynet/sharetable.lua
@@ -2,6 +2,7 @@ local skynet = require "skynet"
 local service = require "skynet.service"
 local core = require "skynet.sharetable.core"
 local is_sharedtable = core.is_sharedtable
+local stackvalues = core.stackvalues
 
 local function sharetable_service()
 	local skynet = require "skynet"
@@ -257,6 +258,10 @@ local function resolve_replace(replace_map)
 
     local function match_value(v)
         assert(v ~= nil)
+        if v == RECORD then
+            return
+        end
+
         local tv = type(v)
         local f = match[tv]
         if record_map[v] or is_sharedtable(v) then
@@ -283,13 +288,33 @@ local function resolve_replace(replace_map)
     end
 
     local function match_table(t)
+        local keys = {}
         for k,v in next, t do
+            local tk = type(k)
+            if match[tk] then
+                keys[#keys+1] = k
+            end
+
             local nv = replace_map[v]
             if nv then
                 nv = getnv(v)
                 rawset(t, k, nv)
             else
                 match_value(v)
+            end
+        end
+
+        for _, old_k in ipairs(keys) do
+            local new_k = replace_map[old_k]
+            if new_k then
+                local value = rawget(t, old_k)
+                new_k = getnv(old_k)
+                rawset(t, old_k, nil)
+                if new_k then
+                    rawset(t, new_k, value)
+                end
+            else
+                match_value(old_k)
             end
         end
         match_mt(t)
@@ -345,8 +370,33 @@ local function resolve_replace(replace_map)
         match_funcinfo(info)
     end
 
+    local stack_values_tmp = {}
     local function match_thread(co)
+        -- match stackvalues
+        local n = stackvalues(co, stack_values_tmp)
+        for i=1,n do
+            local v = stack_values_tmp[i]
+            stack_values_tmp[i] = nil
+            match_value(v)
+        end
+
+        -- match callinfo
         local level = 1
+        -- jump the fucntion from sharetable.update to top
+        local is_self = coroutine.running() == co
+        if is_self then
+            while true do
+                local info = getinfo(co, level, "uf")
+                level = level + 1
+                if not info then
+                    level = 1
+                    break
+                elseif info.func == sharetable.update then
+                    break
+                end
+            end
+        end
+
         while true do
             local info = getinfo(co, level, "uf")
             if not info then
@@ -380,13 +430,15 @@ function sharetable.update(...)
 			for old_t,_ in pairs(map) do
 				if old_t ~= new_t then
 					insert_replace(old_t, new_t, replace_map)
+                    map[old_t] = nil
 				end
 			end
-			RECORD[name] = nil
 		end
 	end
 
-	resolve_replace(replace_map)
+    if next(replace_map) then
+	   resolve_replace(replace_map)
+    end
 end
 
 return sharetable


### PR DESCRIPTION
暂时解决了issue #1096  的问题。 之所以更新不了是因为当通过`coroutine.create(func)`创建出一个co时，同时未执行resume时，是处于suspended状态。此时通过`debug.getinfo`是无法取到`func`的。因为当前co还未被resume过，调用栈是为空。 从而导致func是没法通过lua函数`getinfo`被遍历到，无法做到更新替换。

在lua-sharetable.c代码中实现了`lco_stackvalues`函数来获取创建时的func。

~~~.c
static int
lco_stackvalues(lua_State* L) {
    lua_State *cL = lua_tothread(L, 1);
    luaL_argcheck(L, cL, 1, "thread expected");
    int n = lua_gettop(cL);
    if(n > 0) {
        int i=0;
        lua_checkstack(L, n);
        for(i=0; i<n; i++) {
            setobj2s(L, L->top, cL->top - n + i);
            api_incr_top(L);
        }
        return n;
    }
    return 0;
}
~~~