### PR TITLE
内存统计相关

### DIFF
--- a/3rd/lua/lualib.h
+++ b/3rd/lua/lualib.h
@@ -49,7 +49,7 @@ LUAMOD_API int (luaopen_package) (lua_State *L);
 
 #define LUA_CACHELIB
 LUAMOD_API int (luaopen_cache) (lua_State *L);
-LUALIB_API void (luaL_initcodecache) (void);
+LUALIB_API void (luaL_initcodecache) (lua_Alloc f);
 
 /* open all previous libraries */
 LUALIB_API void (luaL_openlibs) (lua_State *L);

--- a/lualib-src/lua-bson.c
+++ b/lualib-src/lua-bson.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include "atomic.h"
+#include "skynet_malloc.h"
 
 #define DEFAULT_CAP 64
 #define MAX_NUMBER 1024
@@ -65,7 +66,7 @@ get_length(const uint8_t * data) {
 static inline void
 bson_destroy(struct bson *b) {
 	if (b->ptr != b->buffer) {
-		free(b->ptr);
+		skynet_free(b->ptr);
 	}
 }
 
@@ -85,10 +86,10 @@ bson_reserve(struct bson *b, int sz) {
 	} while (b->cap <= b->size + sz);
 
 	if (b->ptr == b->buffer) {
-		b->ptr = malloc(b->cap);
+		b->ptr = skynet_malloc(b->cap);
 		memcpy(b->ptr, b->buffer, b->size);
 	} else {
-		b->ptr = realloc(b->ptr, b->cap);
+		b->ptr = skynet_realloc(b->ptr, b->cap);
 	}
 }
 

--- a/lualib-src/lua-debugchannel.c
+++ b/lualib-src/lua-debugchannel.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "spinlock.h"
+#include "skynet_malloc.h"
 
 #define METANAME "debugchannel"
 
@@ -24,7 +25,7 @@ struct channel {
 
 static struct channel *
 channel_new() {
-	struct channel * c = malloc(sizeof(*c));
+	struct channel * c = skynet_malloc(sizeof(*c));
 	memset(c, 0 , sizeof(*c));
 	c->ref = 1;
 	SPIN_INIT(c)
@@ -58,12 +59,12 @@ channel_release(struct channel *c) {
 	c->tail = NULL;
 	while(p) {
 		struct command *next = p->next;
-		free(p);
+		skynet_free(p);
 		p = next;
 	}
 	SPIN_UNLOCK(c)
 	SPIN_DESTROY(c)
-	free(c);
+	skynet_free(c);
 	return NULL;
 }
 
@@ -90,7 +91,7 @@ channel_read(struct channel *c, double timeout) {
 
 static void
 channel_write(struct channel *c, const char * s, size_t sz) {
-	struct command * cmd = malloc(sizeof(*cmd)+ sz);
+	struct command * cmd = skynet_malloc(sizeof(*cmd)+ sz);
 	cmd->sz = sz;
 	cmd->next = NULL;
 	memcpy(cmd+1, s, sz);
@@ -116,7 +117,7 @@ lread(lua_State *L) {
 	if (c == NULL)
 		return 0;
 	lua_pushlstring(L, (const char *)(c+1), c->sz);
-	free(c);
+	skynet_free(c);
 	return 1;
 }
 

--- a/lualib-src/lua-memory.c
+++ b/lualib-src/lua-memory.c
@@ -61,6 +61,13 @@ lprofactive(lua_State *L) {
 	return 1;
 }
 
+static int
+lwatch(lua_State *L) {
+	uint32_t handle = luaL_checkinteger(L, 1);
+	skynet_memory_watch(handle);
+	return 0;
+}
+
 LUAMOD_API int
 luaopen_skynet_memory(lua_State *L) {
 	luaL_checkversion(L);
@@ -74,6 +81,7 @@ luaopen_skynet_memory(lua_State *L) {
 		{ "current", lcurrent },
 		{ "dumpheap", ldumpheap },
 		{ "profactive", lprofactive },
+		{ "watch", lwatch },
 		{ NULL, NULL },
 	};
 

--- a/lualib-src/lua-sharedata.c
+++ b/lualib-src/lua-sharedata.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <assert.h>
 #include "atomic.h"
+#include "skynet_malloc.h"
 
 #define KEYTYPE_INTEGER 0
 #define KEYTYPE_STRING 1
@@ -150,7 +151,7 @@ setvalue(struct context * ctx, lua_State *L, int index, struct node *n) {
 		break;
 	case LUA_TTABLE: {
 		struct table *tbl = ctx->tbl;
-		ctx->tbl = (struct table *)malloc(sizeof(struct table));
+		ctx->tbl = (struct table *)skynet_malloc(sizeof(struct table));
 		if (ctx->tbl == NULL) {
 			ctx->tbl = tbl;
 			luaL_error(L, "memory error");
@@ -283,14 +284,14 @@ convtable(lua_State *L) {
 
 	int sizearray = lua_rawlen(L, 1);
 	if (sizearray) {
-		tbl->arraytype = (uint8_t *)malloc(sizearray * sizeof(uint8_t));
+		tbl->arraytype = (uint8_t *)skynet_malloc(sizearray * sizeof(uint8_t));
 		if (tbl->arraytype == NULL) {
 			goto memerror;
 		}
 		for (i=0;i<sizearray;i++) {
 			tbl->arraytype[i] = VALUETYPE_NIL;
 		}
-		tbl->array = (union value *)malloc(sizearray * sizeof(union value));
+		tbl->array = (union value *)skynet_malloc(sizearray * sizeof(union value));
 		if (tbl->array == NULL) {
 			goto memerror;
 		}
@@ -298,7 +299,7 @@ convtable(lua_State *L) {
 	}
 	int sizehash = countsize(L, sizearray);
 	if (sizehash) {
-		tbl->hash = (struct node *)malloc(sizehash * sizeof(struct node));
+		tbl->hash = (struct node *)skynet_malloc(sizehash * sizeof(struct node));
 		if (tbl->hash == NULL) {
 			goto memerror;
 		}
@@ -337,10 +338,10 @@ delete_tbl(struct table *tbl) {
 			delete_tbl(tbl->hash[i].v.tbl);
 		}
 	}
-	free(tbl->arraytype);
-	free(tbl->array);
-	free(tbl->hash);
-	free(tbl);
+	skynet_free(tbl->arraytype);
+	skynet_free(tbl->array);
+	skynet_free(tbl->hash);
+	skynet_free(tbl);
 }
 
 static int
@@ -414,7 +415,7 @@ lnewconf(lua_State *L) {
 		lua_pushliteral(L, "memory error");
 		goto error;
 	}
-	tbl = (struct table *)malloc(sizeof(struct table));
+	tbl = (struct table *)skynet_malloc(sizeof(struct table));
 	if (tbl == NULL) {
 		// lua_pushliteral may fail because of memory error, close first.
 		lua_close(ctx.L);

--- a/skynet-src/malloc_hook.h
+++ b/skynet-src/malloc_hook.h
@@ -15,6 +15,7 @@ extern int    mallctl_cmd(const char* name);
 extern void   dump_c_mem(void);
 extern int    dump_mem_lua(lua_State *L);
 extern size_t malloc_current_memory(void);
+extern void   skynet_memory_watch(uint32_t handle);
 
 #endif /* SKYNET_MALLOC_HOOK_H */
 

--- a/skynet-src/skynet_main.c
+++ b/skynet-src/skynet_main.c
@@ -116,6 +116,11 @@ static const char * load_config = "\
 
 int
 main(int argc, char *argv[]) {
+#ifdef LUA_CACHELIB
+	// init the lock of code cache
+	luaL_initcodecache(codecache_lalloc);
+#endif
+
 	const char * config_file = NULL ;
 	if (argc > 1) {
 		config_file = argv[1];
@@ -131,11 +136,6 @@ main(int argc, char *argv[]) {
 	sigign();
 
 	struct skynet_config config;
-
-#ifdef LUA_CACHELIB
-	// init the lock of code cache
-	luaL_initcodecache();
-#endif
 
 	struct lua_State *L = luaL_newstate();
 	luaL_openlibs(L);	// link lua lib

--- a/skynet-src/skynet_malloc.h
+++ b/skynet-src/skynet_malloc.h
@@ -3,20 +3,24 @@
 
 #include <stddef.h>
 
-#define skynet_malloc malloc
-#define skynet_calloc calloc
-#define skynet_realloc realloc
+#define skynet_malloc(sz) skynet_malloc_tag(__LINE__, sz)
+#define skynet_malloc_raw malloc
+#define skynet_calloc(nb, size) skynet_calloc_tag(__LINE__, nb, size)
+#define skynet_calloc_raw calloc
+#define skynet_realloc(ptr, size) skynet_realloc_tag(__LINE__, ptr, size)
+#define skynet_realloc_raw realloc
 #define skynet_free free
 #define skynet_memalign memalign
 #define skynet_aligned_alloc aligned_alloc
 #define skynet_posix_memalign posix_memalign
 
-void * skynet_malloc(size_t sz);
-void * skynet_calloc(size_t nmemb,size_t size);
-void * skynet_realloc(void *ptr, size_t size);
+void * skynet_malloc_tag(unsigned tag, size_t sz);
+void * skynet_calloc_tag(unsigned tag, size_t nmemb,size_t size);
+void * skynet_realloc_tag(unsigned tag, void *ptr, size_t size);
 void skynet_free(void *ptr);
 char * skynet_strdup(const char *str);
 void * skynet_lalloc(void *ptr, size_t osize, size_t nsize);	// use for lua
+void * codecache_lalloc(void* ud, void *ptr, size_t osize, size_t nsize);	// use for lua
 void * skynet_memalign(size_t alignment, size_t size);
 void * skynet_aligned_alloc(size_t alignment, size_t size);
 int skynet_posix_memalign(void **memptr, size_t alignment, size_t size);


### PR DESCRIPTION
codecache的内存统计到“c0decace”项，而不是统计到首先加载代码的服务中而误报内存泄漏。

增加子项统计，对于codecache的内存，标签是文件名的前4个字母，对于其它内存分配，标签是调用skynet_malloc或skynet_realloc的行号。

debug_console增加watchcmem命令，用于设置希望追踪子项的服务，默认是追踪“c0decace”。