### PR TITLE
fix kqueue read with eof

### DIFF
--- a/skynet-src/socket_kqueue.h
+++ b/skynet-src/socket_kqueue.h
@@ -75,7 +75,7 @@ sp_wait(int kfd, struct event *e, int max) {
 		unsigned filter = ev[i].filter;
 		bool eof = (ev[i].flags & EV_EOF) != 0;
 		e[i].write = (filter == EVFILT_WRITE) && (!eof);
-		e[i].read = (filter == EVFILT_READ) && (!eof);
+		e[i].read = (filter == EVFILT_READ);
 		e[i].error = (ev[i].flags & EV_ERROR) != 0;
 		e[i].eof = eof;
 	}


### PR DESCRIPTION
修复问题 #1122 。 之前之所以加上对eof的优先判断，在#858 这个PR中有说明。现在我在我macosx上面测试 `EVFILT_READ` 和`EV_EOF`同时出现时调用`read`系统函数并不会出现`RST`错误了。现在怀疑是macosx新版本把这个行为做了修改。 所以，暂时对read时去掉了对eof的优先判断。