### PR TITLE
fix sharetable update when match self coroutine

### DIFF
--- a/lualib/skynet/sharetable.lua
+++ b/lualib/skynet/sharetable.lua
@@ -421,7 +421,7 @@ local function resolve_replace(replace_map)
             if not info then
                 break
             end
-            info.level = level
+            info.level = is_self and level + 1 or level
             info.curco = co
             match_funcinfo(info)
             level = level + 1


### PR DESCRIPTION
fix #1124 issue.  当调用`match_thread`的是当前co，会跳过从`sharetable.update`函数开始之后的函数调用，但在替换函数内部upvalue和local变量时，因为调用了`match_funcinfo`函数，所以要对level+1.