### PR TITLE
sharetable update bug fixed

### DIFF
--- a/lualib/skynet/sharetable.lua
+++ b/lualib/skynet/sharetable.lua
@@ -304,6 +304,9 @@ local function resolve_replace(replace_map)
 
 
     local function match_table(t)
+        if t == replace_map then
+            return
+        end
         local keys = false
         for k,v in next, t do
             local tk = type(k)


### PR DESCRIPTION
当遍历到sharetable这个chunk的时候，replace_map的key因为是待替换的值会被替换成新值，这以后的遍历替换都会失效。