### PR TITLE
cluster.reload修改某个节点地址，新地址在第一次连接失败(clustersender.changenode失败)后不会再重连

### DIFF
--- a/service/clustersender.lua
+++ b/service/clustersender.lua
@@ -83,15 +83,14 @@ function command.changenode(host, port)
 	if channel then
 		channel:close()
 	end
+	channel = c
 	if succ then
-		channel = c
 		for k, co in ipairs(waiting) do
 			waiting[k] = nil
 			skynet.wakeup(co)
 		end
 		skynet.ret(skynet.pack(nil))
 	else
-		channel = nil	-- reset channel
 		skynet.response()(false)
 	end
 end


### PR DESCRIPTION
cluster.reload修改某个节点地址，新地址在第一次连接失败(clustersender.changenode失败)后，后续cluster.call将永远阻塞不会再重连

修改examples的cluster1.lua和cluster2.lua可以复现这个问题：
examples/cluster1.lua
```lua
local skynet = require "skynet"
local cluster = require "skynet.cluster"
local snax = require "skynet.snax"

skynet.start(function()
	cluster.reload {
		db = "127.0.0.1:2528",
		db2 = "127.0.0.1:2529",
		db3 = "127.0.0.1:2530",
	}

	local sdb = skynet.newservice("simpledb")
	-- register name "sdb" for simpledb, you can use cluster.query() later.
	-- See cluster2.lua
	cluster.register("sdb", sdb)

	print(skynet.call(sdb, "lua", "SET", "a", "foobar"))
	print(skynet.call(sdb, "lua", "SET", "b", "foobar2"))
	print(skynet.call(sdb, "lua", "GET", "a"))
	print(skynet.call(sdb, "lua", "GET", "b"))
	cluster.open "db"
	cluster.open "db2"
	-- unique snax service
	snax.uniqueservice "pingserver"

	-- 等待 cluster2 通知启动 db3
	while true do
		local a = skynet.call(sdb, "lua", "GET", "a")
		if a == "start_db3" then
			break
		end
		skynet.sleep(100)
	end
	skynet.error("start db3, wait 3s")
	skynet.sleep(300)
	cluster.open "db3"
end)
```
examples/cluster2.lua
```lua
local skynet = require "skynet"
local cluster = require "skynet.cluster"

skynet.start(function()
	local proxy = cluster.proxy "db@sdb"	-- cluster.proxy("db", "@sdb")
	local largekey = string.rep("X", 128*1024)
	local largevalue = string.rep("R", 100 * 1024)
	skynet.call(proxy, "lua", "SET", largekey, largevalue)
	local v = skynet.call(proxy, "lua", "GET", largekey)
	assert(largevalue == v)
	skynet.send(proxy, "lua", "PING", "proxy")

	skynet.fork(function()
		skynet.trace("cluster")
		print(cluster.call("db", "@sdb", "GET", "a"))
		print(cluster.call("db2", "@sdb", "GET", "b"))
		cluster.send("db2", "@sdb", "PING", "db2:longstring" .. largevalue)
	end)

	-- test snax service
	skynet.timeout(300,function()
		cluster.reload {
			db = false,	-- db is down
			db3 = "127.0.0.1:2529"
		}
		print(pcall(cluster.call, "db", "@sdb", "GET", "a"))	-- db is down
	end)
	cluster.reload { __nowaiting = false }
	local pingserver = cluster.snax("db3", "pingserver")
	print(pingserver.req.ping "hello")

	cluster.reload{
		db3 = "127.0.0.1:2530",
	}
	print("call from old db3=127.0.0.1:2529 channel", pcall(cluster.call, "db3", "@sdb", "GET", "a"))
	cluster.call("db3", "@sdb", "SET", "a", "start_db3") -- 通知 cluster1 启动 db3
	skynet.sleep(300) -- 等待 clustersender 的 changenode 连接失败，channel将会被置位 nil
	print("call from new db3=127.0.0.1:2530 channel", pcall(cluster.call, "db3", "@sdb", "GET", "a")) -- 这个调用永远阻塞，因为channel == nil
end)
```