### PR TITLE
Improve socketchannel

### DIFF
--- a/lualib/skynet/db/mongo.lua
+++ b/lualib/skynet/db/mongo.lua
@@ -112,38 +112,15 @@ local function mongo_auth(mongoc)
 				mongoc.__sock:changebackup(backup)
 			end
 			if rs_data.ismaster	then
-				if rawget(mongoc, "__pickserver") then
-					rawset(mongoc, "__pickserver", nil)
-				end
 				return
+			elseif rs_data.primary then
+				local host,	port = __parse_addr(rs_data.primary)
+				mongoc.host	= host
+				mongoc.port	= port
+				mongoc.__sock:changehost(host, port)
 			else
-				if rs_data.primary then
-					local host,	port = __parse_addr(rs_data.primary)
-					mongoc.host	= host
-					mongoc.port	= port
-					mongoc.__sock:changehost(host, port)
-				else
-					skynet.error("WARNING: NO PRIMARY RETURN " .. rs_data.me)
-					-- determine the primary db using hosts
-					local pickserver = {}
-					if rawget(mongoc, "__pickserver") == nil then
-						for _, v in ipairs(rs_data.hosts) do
-							if v ~= rs_data.me then
-								table.insert(pickserver, v)
-							end
-							rawset(mongoc, "__pickserver", pickserver)
-						end
-					end
-					if #mongoc.__pickserver <= 0 then
-						error("CAN NOT DETERMINE THE PRIMARY DB")
-					end
-					skynet.error("INFO: TRY TO CONNECT " .. mongoc.__pickserver[1])
-					local host, port = __parse_addr(mongoc.__pickserver[1])
-					table.remove(mongoc.__pickserver, 1)
-					mongoc.host	= host
-					mongoc.port	= port
-					mongoc.__sock:changehost(host, port)
-				end
+				-- socketchannel would try the next host in backup list
+				error ("No primary return : " .. tostring(rs_data.me))
 			end
 		end
 	end


### PR DESCRIPTION
See issue #1145

改进 socket channel, 在 auth 失败后，会尝试连接 backup 列表（若提供）中下一个 host 。

之前的实现 socket channel 仅当连接主 host 失败后才尝试连接 backup 。

由于 socket channel 实现了这个特性， mongodb driver 就不必额外实现 pickserver 功能。在找不到主节点时，直接抛出 error 即可。

这个 patch 的主要改变是将原来的 `connect_once` 函数包装了一层，原来逻辑放在内部函数 `_connect_once` 中，包装层会复制一份 backup 列表，在 `_connect_once` 建立连接失败（包括 socket 建立失败，及 auth 过程发生 error ）后，尝试列表中没有试过的 host 。

注: 如果 auth 过程主动调用 changehost ，而非抛出 error ，则会重试整个 `connect_once` 过程。

btw，这个 patch 改动并不太大。之所以 diff 看起来很复杂，是因为 `_connect_once` 相对 `connect_once` 改动了缩进层次。