### PR TITLE
协程调度尾调用优化

### DIFF
--- a/lualib/skynet.lua
+++ b/lualib/skynet.lua
@@ -161,6 +161,8 @@ local function dispatch_wakeup()
 			session_id_coroutine[session] = "BREAK"
 			return suspend(co, coroutine_resume(co, false, "BREAK"))
 		end
+	else
+		return dispatch_error_queue()
 	end
 end
 
@@ -184,8 +186,7 @@ function suspend(co, result, command)
 		error(traceback(co,tostring(command)))
 	end
 	if command == "SUSPEND" then
-		dispatch_wakeup()
-		dispatch_error_queue()
+		return dispatch_wakeup()
 	elseif command == "QUIT" then
 		-- service exit
 		return

--- a/lualib/skynet.lua
+++ b/lualib/skynet.lua
@@ -151,19 +151,22 @@ local function co_create(f)
 end
 
 local function dispatch_wakeup()
-	local token = tremove(wakeup_queue,1)
-	if token then
-		local session = sleep_session[token]
-		if session then
-			local co = session_id_coroutine[session]
-			local tag = session_coroutine_tracetag[co]
-			if tag then c.trace(tag, "resume") end
-			session_id_coroutine[session] = "BREAK"
-			return suspend(co, coroutine_resume(co, false, "BREAK"))
+	while true do
+		local token = tremove(wakeup_queue,1)
+		if token then
+			local session = sleep_session[token]
+			if session then
+				local co = session_id_coroutine[session]
+				local tag = session_coroutine_tracetag[co]
+				if tag then c.trace(tag, "resume") end
+				session_id_coroutine[session] = "BREAK"
+				return suspend(co, coroutine_resume(co, false, "BREAK"))
+			end
+		else
+			break
 		end
-	else
-		return dispatch_error_queue()
 	end
+	return dispatch_error_queue()
 end
 
 -- suspend is local function


### PR DESCRIPTION
测试skynet lua5.4版本发现报错`C stack overflow`
分析了一下原因
* 我的测试用例中skynet的`wakeup_queue`有大量待执行的协程
* 目前suspend函数的实现在上面的条件下有可能会导致递归执行suspend,导致lua栈大量增长.
* lua5.4的`OP_CALL`的实现的变化导致lua堆栈的增长会导致c堆栈的增长
1. lua5.4
```c
vmcase(OP_CALL) {
        // ......
        ProtectNT(luaD_call(L, ra, nresults));
```
> `luaD_call`中再去调用`luaV_execute`
2.  lua5.3
```c
vmcase(OP_CALL) {
	// ......
	else {  /* Lua function */
		ci = L->ci;
		goto newframe;  /* restart luaV_execute over new Lua function */
	}
```