### PR TITLE
mysql : 修复读写负数导致溢出处错误 (#1182)

### DIFF
--- a/lualib/skynet/db/mysql.lua
+++ b/lualib/skynet/db/mysql.lua
@@ -4,6 +4,8 @@
 -- The license is under the BSD license.
 -- Modified by Cloud Wu (remove bit32 for lua 5.3)
 
+-- protocol detail: https://mariadb.com/kb/en/clientserver-protocol/
+
 local socketchannel = require "skynet.socketchannel"
 local crypt = require "skynet.crypt"
 
@@ -96,40 +98,39 @@ converters[0x09] = tonumber -- int24
 converters[0x0d] = tonumber -- year
 converters[0xf6] = tonumber -- newdecimal
 
-local function _get_byte1(data, i)
+local function _get_byte1(data, i, is_signed)
+    if is_signed then
+        return strunpack("<i1", data, i)
+    end
     return strbyte(data, i), i + 1
 end
 
-local function _get_int1(data, i)
-    return strunpack("<i1", data, i)
-end
-
-local function _get_byte2(data, i)
+local function _get_byte2(data, i, is_signed)
+    if is_signed then
+        return strunpack("<i2", data, i)
+    end
     return strunpack("<I2", data, i)
 end
 
-local function _get_int2(data, i)
-    return strunpack("<i2", data, i)
-end
-
-local function _get_byte3(data, i)
+local function _get_byte3(data, i, is_signed)
+    if is_signed then
+        return strunpack("<i3", data, i)
+    end
     return strunpack("<I3", data, i)
 end
 
-local function _get_byte4(data, i)
+local function _get_byte4(data, i, is_signed)
+    if is_signed then
+        return strunpack("<i4", data, i)
+    end
     return strunpack("<I4", data, i)
 end
 
-local function _get_int4(data, i)
-    return strunpack("<i4", data, i)
-end
-
-local function _get_byte8(data, i)
+local function _get_byte8(data, i, is_signed)
+    if is_signed then
+        return strunpack("<i8", data, i)
+    end
     return strunpack("<I8", data, i)
-end
-
-local function _get_int8(data, i)
-    return strunpack("<i8", data, i)
 end
 
 local function _get_float(data, i)
@@ -354,10 +355,12 @@ local function _parse_field_packet(data)
     charsetnr, pos = _get_byte2(data, pos)
     length, pos = _get_byte4(data, pos)
     col.type = strbyte(data, pos)
-
-    --[[
     pos = pos + 1
-    col.flags, pos = _get_byte2(data, pos)
+    local flags, pos = _get_byte2(data, pos)
+    if flags & 0x20 == 0 then -- https://mariadb.com/kb/en/resultset/
+        col.is_signed = true
+    end
+    --[[
     col.decimals = strbyte(data, pos)
     pos = pos + 1
     local default = sub(data, pos + 2)
@@ -805,13 +808,13 @@ end
 
 -- 字段类型参考 https://dev.mysql.com/doc/dev/mysql-server/8.0.12/binary__log__types_8h.html enum_field_types 枚举类型定义
 local _binary_parser = {
-    [0x01] = _get_int1,
-    [0x02] = _get_int2,
-    [0x03] = _get_int4,
+    [0x01] = _get_byte1,
+    [0x02] = _get_byte2,
+    [0x03] = _get_byte4,
     [0x04] = _get_float,
     [0x05] = _get_double,
     [0x07] = _get_datetime,
-    [0x08] = _get_int8,
+    [0x08] = _get_byte8,
     [0x0c] = _get_datetime,
     [0x0f] = _from_length_coded_str,
     [0x10] = _from_length_coded_str,
@@ -859,7 +862,7 @@ local function _parse_row_data_binary(data, cols, compact)
             if not parser then
                 error("_parse_row_data_binary()error,unsupported field type " .. typ)
             end
-            value, pos = parser(data, pos)
+            value, pos = parser(data, pos, col.is_signed)
             if compact then
                 row[i] = value
             else

--- a/test/testmysql.lua
+++ b/test/testmysql.lua
@@ -118,17 +118,17 @@ local function test_sp_blob(db)
 end
 
 local function test_signed(db)
-    local res = db:query("drop table if exists signed_cats")
-    res = db:query("create table signed_cats " .. "(id tinyint primary key, " .. "name varchar(5))")
+    local res = db:query("drop table if exists test_i_u")
+    res = db:query("create table test_i_u (i tinyint primary key, u tinyint unsigned)")
     print(dump(res))
 
-    res = db:query("insert into signed_cats (id,name) " .. "values (-1,'Bob'),(127,''),(-127,null)")
+    res = db:query("insert into test_i_u (i,u) values (-1,1),(127,128),(-127,255)")
     print(dump(res))
 
-    local prep = "SELECT * FROM signed_cats WHERE id!=?"
+    local prep = "SELECT * FROM test_i_u"
     local stmt = db:prepare(prep)
-    local res = db:execute(stmt, -100)
-    print("execute -100: ", dump(res))
+    local res = db:execute(stmt)
+    print("test_i_u: ", dump(res))
     db:stmt_close(stmt)
 end
 

--- a/test/testmysql.lua
+++ b/test/testmysql.lua
@@ -117,6 +117,21 @@ local function test_sp_blob(db)
 	print("test stored procedure ok")
 end
 
+local function test_signed(db)
+    local res = db:query("drop table if exists signed_cats")
+    res = db:query("create table signed_cats " .. "(id tinyint primary key, " .. "name varchar(5))")
+    print(dump(res))
+
+    res = db:query("insert into signed_cats (id,name) " .. "values (-1,'Bob'),(127,''),(-127,null)")
+    print(dump(res))
+
+    local prep = "SELECT * FROM signed_cats WHERE id!=?"
+    local stmt = db:prepare(prep)
+    local res = db:execute(stmt, -100)
+    print("execute -100: ", dump(res))
+    db:stmt_close(stmt)
+end
+
 skynet.start(function()
 
 	local function on_connect(db)
@@ -151,6 +166,8 @@ skynet.start(function()
 
 	-- 测试存储过程和二进制blob
 	test_sp_blob(db)
+	
+	test_signed(db)
 
     -- test in another coroutine
 	skynet.fork( test2, db)


### PR DESCRIPTION
客户端其实是没法直接通过数据类型判断服务器发来的数据是否有无符号的.需要通过列定义包中的标志位来判断.
[https://mariadb.com/kb/en/resultset](https://mariadb.com/kb/en/resultset)
整型数据也不能统一按符号型(I\<n\>)处理,不然会导致错误.比如服务器存储了一个unsigned tinyint,其值为0xFF,都按照有符号整型处理,客户端是取不到255(<I1)这个值的,只能取到-1(<i1).