### PR TITLE
Update socket.lua

### DIFF
--- a/lualib/skynet/socket.lua
+++ b/lualib/skynet/socket.lua
@@ -112,6 +112,10 @@ socket_message[5] = function(id, _, err)
 		skynet.error("socket: error on unknown", id, err)
 		return
 	end
+	if s.callback then
+		skynet.error("socket: accpet error:", err)	
+		return
+	end
 	if s.connected then
 		skynet.error("socket: error on", id, err)
 	elseif s.connecting then


### PR DESCRIPTION
如果监听套接字在accept时异常（例如：errno == EMFILE），那么不应该关闭监听套接字本身，输出异常信息即可。