### PR TITLE
优化sharetable更新

### DIFF
--- a/lualib/skynet/sharetable.lua
+++ b/lualib/skynet/sharetable.lua
@@ -258,16 +258,12 @@ local function resolve_replace(replace_map)
 
     local function match_value(v)
         assert(v ~= nil)
-        if v == RECORD then
+        if record_map[v] or is_sharedtable(v) then
             return
         end
 
         local tv = type(v)
         local f = match[tv]
-        if record_map[v] or is_sharedtable(v) then
-            return
-        end
-
         if f then
             record_map[v] = true
             f(v)
@@ -364,7 +360,7 @@ local function resolve_replace(replace_map)
         end
 
         local level = info.level
-        local curco = info.curco or coroutine.running()
+        local curco = info.curco
         if not level then
             return
         end
@@ -390,7 +386,7 @@ local function resolve_replace(replace_map)
     end
 
     local stack_values_tmp = {}
-    local function match_thread(co)
+    local function match_thread(co, level)
         -- match stackvalues
         local n = stackvalues(co, stack_values_tmp)
         for i=1,n do
@@ -399,33 +395,29 @@ local function resolve_replace(replace_map)
             match_value(v)
         end
 
-        -- match callinfo
-        local level = 1
-        -- jump the fucntion from sharetable.update to top
-        local is_self = coroutine.running() == co
-        if is_self then
-            while true do
-                local info = getinfo(co, level, "uf")
-                level = level + 1
-                if not info then
-                    level = 1
-                    break
-                elseif info.func == sharetable.update then
-                    break
-                end
-            end
-        end
-
+        level = level or 1
         while true do
             local info = getinfo(co, level, "uf")
             if not info then
                 break
             end
-            info.level = is_self and level + 1 or level
+            info.level = level
             info.curco = co
             match_funcinfo(info)
             level = level + 1
         end
+    end
+
+    local function prepare_match()
+        local co = coroutine.running()
+        record_map[co] = true
+        record_map[match] = true
+        record_map[RECORD] = true
+        record_map[record_map] = true
+        record_map[insert_replace] = true
+        record_map[resolve_replace] = true
+        assert(getinfo(co, 3, "f").func == sharetable.update)
+        match_thread(co, 5) -- ignore match_thread and match_funcinfo frame
     end
 
     match["table"] = match_table
@@ -433,6 +425,7 @@ local function resolve_replace(replace_map)
     match["userdata"] = match_userdata
     match["thread"] = match_thread
 
+    prepare_match()
     match_internmt()
 
     local root = debug.getregistry()


### PR DESCRIPTION
修改了sharetable 的update遍历当前coroutine的行为。改为match前先遍历，同时添加了record_map记录。