### PR TITLE
Update clusteragent.lua

### DIFF
--- a/service/clusteragent.lua
+++ b/service/clusteragent.lua
@@ -140,7 +140,7 @@ skynet.start(function()
 		elseif cmd == "namechange" then
 			register_name = new_register_name()
 		else
-			skynet.error(string.format("Invalid command %s from %s", cmd, skynet.address(source)))
+			error(string.format("Invalid command %s from %s", cmd, skynet.address(source)))
 		end
 	end)
 end)


### PR DESCRIPTION
首先贴一下错误描述：
[:0000002b] Invalid command findPlayerInRoom from :00000055
[:0000002b] Maybe forgot response session 3 from :00000055 : @./skynet/service/clusteragent.lua:136

集群节点A访问集群节点B的某类服务{a,b,c}，比如节点B的某种服务的地址为{53, 55, 56}，AB节点启动后，A节点用cluster.call访问B节点的地址为55的服务,第一次正常访问，如果B节点重启，某种服务的地址变为{53, 54, 56}，这时如果集群节点A再次通过cluster.call访问B节点的地址为55的服务会一直得不到反馈，协程就一直卡在那了，我这边试了作了这个修改后，节点A那边就能得到反馈了。