### PR TITLE
fix lua_sharestring

### DIFF
--- a/3rd/lua/lapi.c
+++ b/3rd/lua/lapi.c
@@ -1101,11 +1101,9 @@ LUA_API void lua_sharefunction (lua_State *L, int index) {
 }
 
 LUA_API void lua_sharestring (lua_State *L, int index) {
-  const char *str = lua_tostring(L, index);
-  if (str == NULL)
+  if (lua_type(L,index) != LUA_TSTRING)
     luaG_runerror(L, "need a string to share");
-
-  TString *ts = (TString *)(str - sizeof(TString));
+  TString *ts = tsvalue(index2value(L,index));
   luaS_share(ts);
 }
 


### PR DESCRIPTION
`struct TString` 结构改了
```c
/*
** Get the actual string (array of bytes) from a 'TString'.
*/
#define getstr(ts)  ((ts)->contents)
```