### PR TITLE
Invalid addrinfo pointer casues skynet asserted in freeaddrinfo on Op…

### DIFF
--- a/skynet-src/socket_server.c
+++ b/skynet-src/socket_server.c
@@ -594,7 +594,7 @@ open_socket(struct socket_server *ss, struct request_open * request, struct sock
 	status = getaddrinfo( request->host, port, &ai_hints, &ai_list );
 	if ( status != 0 ) {
 		result->data = (void *)gai_strerror(status);
-		goto _failed;
+		goto _failed_getaddrinfo;
 	}
 	int sock= -1;
 	for (ai_ptr = ai_list; ai_ptr != NULL; ai_ptr = ai_ptr->ai_next ) {
@@ -643,6 +643,7 @@ open_socket(struct socket_server *ss, struct request_open * request, struct sock
 	return -1;
 _failed:
 	freeaddrinfo( ai_list );
+_failed_getaddrinfo:
 	ss->slot[HASH_ID(id)].type = SOCKET_TYPE_INVALID;
 	return SOCKET_ERR;
 }


### PR DESCRIPTION
Skynet is used on openwrt ARM embedded device, and httpc module is used for downloading Lua packages from HTTP server. And skynet crashed when that embedded device network is unavailable.

That crash is happened inside freeaddrinfo function with invalid addrinfo data.