### PR TITLE
fix sharetable update and tail call

### DIFF
--- a/lualib/skynet/sharetable.lua
+++ b/lualib/skynet/sharetable.lua
@@ -265,7 +265,7 @@ local function resolve_replace(replace_map)
         local f = match[tv]
         if f then
             record_map[v] = true
-            f(v)
+            return f(v)
         end
     end
 
@@ -277,7 +277,7 @@ local function resolve_replace(replace_map)
                 nv = getnv(mt)
                 debug.setmetatable(v, nv)
             else
-                match_value(mt)
+                return match_value(mt)
             end
         end
     end
@@ -294,7 +294,7 @@ local function resolve_replace(replace_map)
         for _,v in pairs(internal_types) do
             match_mt(v)
         end
-        match_mt(nil)
+        return match_mt(nil)
     end
 
 
@@ -331,7 +331,7 @@ local function resolve_replace(replace_map)
                 end
             end
         end
-        match_mt(t)
+        return match_mt(t)
     end
 
     local function match_userdata(u)
@@ -341,7 +341,7 @@ local function resolve_replace(replace_map)
             nv = getnv(uv)
             setuservalue(u, nv)
         end
-        match_mt(u)
+        return match_mt(u)
     end
 
     local function match_funcinfo(info)
@@ -381,7 +381,7 @@ local function resolve_replace(replace_map)
 
     local function match_function(f)
         local info = getinfo(f, "uf")
-        match_funcinfo(info)
+        return match_funcinfo(info)
     end
 
     local function match_thread(co, level)
@@ -393,13 +393,14 @@ local function resolve_replace(replace_map)
             match_value(v)
         end
 
+        local uplevel = co == coroutine.running() and 1 or 0
         level = level or 1
         while true do
             local info = getinfo(co, level, "uf")
             if not info then
                 break
             end
-            info.level = level
+            info.level = level + uplevel
             info.curco = co
             match_funcinfo(info)
             level = level + 1
@@ -412,6 +413,7 @@ local function resolve_replace(replace_map)
         record_map[match] = true
         record_map[RECORD] = true
         record_map[record_map] = true
+        record_map[replace_map] = true
         record_map[insert_replace] = true
         record_map[resolve_replace] = true
         assert(getinfo(co, 3, "f").func == sharetable.update)
@@ -449,7 +451,7 @@ function sharetable.update(...)
 	end
 
     if next(replace_map) then
-	   resolve_replace(replace_map)
+        resolve_replace(replace_map)
     end
 end
 


### PR DESCRIPTION
1. 将`match`尽可能的改成了tail call；减少出现`stack overflow`错误的概率。(lua5.4.2改为了stackless调用，问题不那么严重)
2. 修复了在调用`sharetable.update`的coroutine中，调用栈替换错误导致`replace_map`被替换的bug。