### PR TITLE
fix socket half close

### DIFF
--- a/skynet-src/socket_server.c
+++ b/skynet-src/socket_server.c
@@ -1357,8 +1357,14 @@ forward_message_tcp(struct socket_server *ss, struct socket *s, struct socket_lo
 	}
 	if (n==0) {
 		FREE(buffer);
-		force_close(ss, s, l, result);
-		return SOCKET_CLOSE;
+		if (nomore_sending_data(s)) {
+			force_close(ss,s,l,result); 
+			return SOCKET_CLOSE;
+		} else { 
+			s->type = SOCKET_TYPE_HALFCLOSE;
+			shutdown(s->fd, SHUT_RD);
+			return -1; 
+		}
 	}
 
 	if (s->type == SOCKET_TYPE_HALFCLOSE) {


### PR DESCRIPTION
当收到客户端`shutdown SHUT_WT`时会判断当前`wbuffer`中是否还有数据， 如果是有数据将会进入`SOCKET_TYPE_HALFCLOSE`状态，等待发送完全之后再`close socket`.

https://github.com/cloudwu/skynet/issues/50 此issue可以解决。