### PR TITLE
fixed mongodb werror return errmsg

### DIFF
--- a/lualib/skynet/db/mongo.lua
+++ b/lualib/skynet/db/mongo.lua
@@ -333,14 +333,16 @@ function mongo_collection:insert(doc)
 end
 
 local function werror(r)
-	local ok = (r.ok == 1 and not r.writeErrors and not r.writeConcernError)
+	local ok = (r.ok == 1 and not r.writeErrors and not r.writeConcernError and not r.errmsg)
 
 	local err
 	if not ok then
 		if r.writeErrors then
 			err = r.writeErrors[1].errmsg
-		else
+		elseif r.writeConcernError then
 			err = r.writeConcernError.errmsg
+		else
+			err = r.errmsg
 		end
 	end
 	return ok, err, r


### PR DESCRIPTION
使用 Mongodb 4.4.1 版本时发现错误消息的字段为 `r.errmsg`