### PR TITLE
fix shared function

### DIFF
--- a/lualib-src/lua-sharetable.c
+++ b/lualib-src/lua-sharetable.c
@@ -41,6 +41,7 @@ mark_shared(lua_State *L) {
 				} else if (!lua_iscfunction(L, idx)) {
 					LClosure *f = (LClosure *)lua_topointer(L, idx);
 					makeshared(f);
+					lua_sharefunction(L, idx);
 				}
 				break;
 			case LUA_TSTRING:


### PR DESCRIPTION
对于如下测试用例:
~~~.lua
sharetable.loadstring("test_func", [[return {
		test_func = function (print, t)
			print(t.aa, t.aa == "abc")
		end,
	}]])

	local t = sharetable.query("test_func")
	local tmp = {"a", "b", "c"}
	local s = table.concat(tmp, "")
	print("s", s)
	t.test_func(print, {
		aa = s,
	})

-- output
--[[
s	abc
abc	false
]]
~~~
因为共享的function只是标记了closure，没有标记常量和proto，所以会导致内部hash计算错误。同时，如果返回共享函数内部的常量字符串给外部用的话，可能会导致把本来应该共享的对象，会被标记到。
有个疑问是，不确定hared的function 拿到之后在另外个vm里面用， 还用不用先clonefunction下？
现在不用clone也能用的。