### PR TITLE
 bugfix ltls init #1314

### DIFF
--- a/lualib-src/ltls.c
+++ b/lualib-src/ltls.c
@@ -378,9 +378,11 @@ lnew_tls(lua_State* L) {
     return 1;
 }
 
-
 int
 luaopen_ltls_c(lua_State* L) {
+    if(!TLS_IS_INIT) {
+        luaL_error(L, "ltls need init.");
+    }
     luaL_Reg l[] = {
         {"newctx", lnew_ctx},
         {"newtls", lnew_tls},
@@ -391,18 +393,23 @@ luaopen_ltls_c(lua_State* L) {
     return 1;
 }
 
-void __attribute__((constructor)) ltls_init(void) {
+// for ltls init
+static int
+ltls_init_constructor(lua_State* L) {
 #ifndef OPENSSL_EXTERNAL_INITIALIZATION
-    SSL_library_init();
-    SSL_load_error_strings();
-    ERR_load_BIO_strings();
-    OpenSSL_add_all_algorithms();
-    TLS_IS_INIT = true;
+    if(!TLS_IS_INIT) {
+        SSL_library_init();
+        SSL_load_error_strings();
+        ERR_load_BIO_strings();
+        OpenSSL_add_all_algorithms();
+    }
 #endif
+    TLS_IS_INIT = true;
+    return 0;
 }
 
-
-void __attribute__((destructor)) ltls_destory(void) {
+static int
+ltls_init_destructor(lua_State* L) {
     if(TLS_IS_INIT) {
         ENGINE_cleanup();
         CONF_modules_unload(1);
@@ -411,4 +418,18 @@ void __attribute__((destructor)) ltls_destory(void) {
         sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
         CRYPTO_cleanup_all_ex_data();
     }
+    TLS_IS_INIT = false;
+    return 0;
+}
+
+int
+luaopen_ltls_init_c(lua_State* L) {
+    luaL_Reg l[] = {
+        {"constructor", ltls_init_constructor},
+        {"destructor", ltls_init_destructor},
+        {NULL, NULL},
+    };
+    luaL_checkversion(L);
+    luaL_newlib(L, l);
+    return 1;
 }

--- a/lualib-src/ltls.c
+++ b/lualib-src/ltls.c
@@ -381,7 +381,7 @@ lnew_tls(lua_State* L) {
 int
 luaopen_ltls_c(lua_State* L) {
     if(!TLS_IS_INIT) {
-        luaL_error(L, "ltls need init.");
+        luaL_error(L, "ltls need init, Put enablessl = true in you config file.");
     }
     luaL_Reg l[] = {
         {"newctx", lnew_ctx},

--- a/lualib-src/ltls.c
+++ b/lualib-src/ltls.c
@@ -410,6 +410,7 @@ ltls_init_constructor(lua_State* L) {
 
 static int
 ltls_init_destructor(lua_State* L) {
+#ifndef OPENSSL_EXTERNAL_INITIALIZATION
     if(TLS_IS_INIT) {
         ENGINE_cleanup();
         CONF_modules_unload(1);
@@ -418,6 +419,7 @@ ltls_init_destructor(lua_State* L) {
         sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
         CRYPTO_cleanup_all_ex_data();
     }
+#endif
     TLS_IS_INIT = false;
     return 0;
 }

--- a/service/bootstrap.lua
+++ b/service/bootstrap.lua
@@ -1,5 +1,6 @@
 local skynet = require "skynet"
 local harbor = require "skynet.harbor"
+local service = require "skynet.service"
 require "skynet.manager"	-- import skynet.launch, ...
 
 skynet.start(function()
@@ -39,6 +40,15 @@ skynet.start(function()
 		skynet.name("DATACENTER", datacenter)
 	end
 	skynet.newservice "service_mgr"
+
+	local enablessl = skynet.getenv "enablessl"
+	if enablessl then
+		service.new("ltls_holder", function ()
+			local c = require "ltls.init.c"
+			c.constructor()
+		end)
+	end
+
 	pcall(skynet.newservice,skynet.getenv "start" or "main")
 	skynet.exit()
 end)


### PR DESCRIPTION
1. 添加了`ltls.init.c`接口用来做`ltls`的初始化。
2. 初始化接口在`bootstrap`中由创建的`ltls_holder`服务来进行调用，保证整个skynet进程生命周期中so只会load一次。
3. 目前是导出了`constructor`和`destructor`两个接口，`destructor`接口暂时没做调用。
4. 开启https功能现在多了一个参数，需要在`config`启动文件里面加上`enablessl = true`。