### PR TITLE
fixed MYCFLAGS=-D__STDC_NO_ATOMICS__ in shell. See #1317

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LUA_LIB ?= $(LUA_STATICLIB)
 LUA_INC ?= 3rd/lua
 
 $(LUA_STATICLIB) :
-	cd 3rd/lua && $(MAKE) CC='$(CC) -std=gnu99' $(PLAT)
+	cd 3rd/lua && $(MAKE) CC='$(CC) -std=gnu99' $(PLAT) MYCFLAGS='$(MYCFLAGS) -I../../skynet-src -g'
 
 # https : turn on TLS_MODULE to add https support
 


### PR DESCRIPTION
修复从命令行执行下面命令报错

```sh
make linux MYCFLAGS=-D__STDC_NO_ATOMICS__
```