### PR TITLE
skynet.init

### DIFF
--- a/lualib/skynet.lua
+++ b/lualib/skynet.lua
@@ -927,6 +927,20 @@ end
 
 local init_func = {}
 
+function skynet.init(f, name)
+	assert(type(f) == "function")
+	if init_func == nil then
+		f()
+	else
+		tinsert(init_func, f)
+		if name then
+			assert(type(name) == "string")
+			assert(init_func[name] == nil)
+			init_func[name] = f
+		end
+	end
+end
+
 local function init_all()
 	local funcs = init_func
 	if funcs then
@@ -934,20 +948,6 @@ local function init_all()
 			f()
 		end
 		init_func = nil
-	end
-end
-
-function skynet.init(f, name)
-	assert(type(f) == "function")
-	if init_func == nil then
-		init_func = {}
-		skynet.fork(init_all)
-	end
-	tinsert(init_func, f)
-	if name then
-		assert(type(name) == "string")
-		assert(init_func[name] == nil)
-		init_func[name] = f
 	end
 end
 

--- a/lualib/skynet.lua
+++ b/lualib/skynet.lua
@@ -530,7 +530,7 @@ function skynet.exit()
 		end
 	end
 	for session, co in pairs(session_id_coroutine) do
-		if type(co) == "thread" then
+		if type(co) == "thread" and co ~= running_thread then
 			coroutine.close(co)
 		end
 	end
@@ -927,27 +927,27 @@ end
 
 local init_func = {}
 
-function skynet.init(f, name)
-	assert(type(f) == "function")
-	if init_func == nil then
-		f()
-	else
-		tinsert(init_func, f)
-		if name then
-			assert(type(name) == "string")
-			assert(init_func[name] == nil)
-			init_func[name] = f
-		end
-	end
-end
-
 local function init_all()
 	local funcs = init_func
-	init_func = nil
 	if funcs then
 		for _,f in ipairs(funcs) do
 			f()
 		end
+		init_func = nil
+	end
+end
+
+function skynet.init(f, name)
+	assert(type(f) == "function")
+	if init_func == nil then
+		init_func = {}
+		skynet.fork(init_all)
+	end
+	tinsert(init_func, f)
+	if name then
+		assert(type(name) == "string")
+		assert(init_func[name] == nil)
+		init_func[name] = f
 	end
 end
 


### PR DESCRIPTION
fix:在`skynet.init`的加载过程中`require`新的包含`skynet.init`的代码会异常,且服务没有退出
```lua
local skynet = require "skynet"
package.preload.testcase=assert(load([[
    local skynet = require "skynet"
    skynet.init(function()
        skynet.sleep(100)
        skynet.error("sleep")
    end)
]], "test", "t", _ENV))

skynet.init(function()
    require("testcase")
end)
skynet.start(function()
    skynet.exit()
end)
```

```
[:01000010] LAUNCH snlua testcase
[:01000010] init service failed: attempt to yield across a C-call boundary
stack traceback:
        [C]: in function 'coroutine.yield'
        ./lualib/skynet.lua:389: in upvalue 'suspend_sleep'
        ./lualib/skynet.lua:396: in function 'skynet.sleep'
        [string "test"]:3: in local 'f'
        ./lualib/skynet.lua:933: in function 'skynet.init'
        [string "test"]:2: in main chunk
        [C]: in function 'require'
        ./test/testcase.lua:11: in local 'f'
        ./lualib/skynet.lua:949: in upvalue 'init_all'
        ./lualib/skynet.lua:960: in function <./lualib/skynet.lua:959>
        [C]: in function 'xpcall'
        ./lualib/skynet.lua:966: in function 'skynet.pcall'
        ./lualib/skynet.lua:970: in function 'skynet.init_service'
        ./lualib/skynet.lua:983: in upvalue 'f'
        ./lualib/skynet.lua:252: in function <./lualib/skynet.lua:251>
[:01000010] lua call [0 to :1000010 : 1 msgsz = 0] error : ./lualib/skynet.lua:858: ./lualib/skynet.lua:329: ./lualib/skynet.lua:534: cannot close a running coroutine
stack traceback:
        [C]: in function 'coroutine.close'
        ./lualib/skynet.lua:534: in function 'skynet.exit'
        ./lualib/skynet.lua:974: in function 'skynet.init_service'
        ./lualib/skynet.lua:983: in upvalue 'f'
        ./lualib/skynet.lua:252: in function <./lualib/skynet.lua:251>
stack traceback:
        [C]: in function 'assert'
        ./lualib/skynet.lua:858: in function 'skynet.dispatch_message'
[:01000010] lua call [0 to :1000010 : 2 msgsz = 0] error : ./lualib/skynet.lua:858: ./lualib/skynet.lua:329: cannot resume dead coroutine
stack traceback:
stack traceback:
        [C]: in function 'assert'
        ./lualib/skynet.lua:858: in function 'skynet.dispatch_message'
```