### PR TITLE
Spinlock try lock failed,  should yield current thread.

### DIFF
--- a/skynet-src/spinlock.h
+++ b/skynet-src/spinlock.h
@@ -25,6 +25,8 @@
 
 #endif
 
+#include <sched.h>
+
 struct spinlock {
 	atomic_flag_ lock;
 };
@@ -37,7 +39,12 @@ spinlock_init(struct spinlock *lock) {
 
 static inline void
 spinlock_lock(struct spinlock *lock) {
-	while (atomic_flag_test_and_set_(&lock->lock)) {}
+	unsigned int counter = 0;
+	while (atomic_flag_test_and_set_(&lock->lock)) {
+		if(++counter>1000){
+			sched_yield();
+		}
+	}
 }
 
 static inline int


### PR DESCRIPTION

see https://probablydance.com/2019/12/30/measuring-mutexes-spinlocks-and-how-bad-the-linux-scheduler-really-is/

terrible_spinlock: like spinlock.h 

Type | Average test duration | Four longest waits
-- | -- | --
std::mutex | 62 ms | 2.9 ms, 2.8 ms, 1.5 ms, 1.4 ms
terrible_spinlock | 825 ms | 103.5 ms, 90.6 ms, 77.1 ms, 75.7 ms
spinlock_amd | 68 ms | 62.3 ms, 61.5 ms, 60.9 ms, 59.8 ms
spinlock | 69 ms | 11.4 ms, 10.8 ms, 10.4 ms, 9.9 ms
ticket_spinlock | 93 ms | 1.5 ms, 1.5 ms, 1.49 ms, 1.48 ms