### PR TITLE
socket.onclose()

### DIFF
--- a/lualib/skynet/socket.lua
+++ b/lualib/skynet/socket.lua
@@ -123,6 +123,9 @@ socket_message[3] = function(id)
 	end
 	s.connected = false
 	wakeup(s)
+	if s.on_close then
+		s.on_close(id)
+	end
 end
 
 -- SKYNET_SOCKET_TYPE_ACCEPT = 4
@@ -483,6 +486,12 @@ function socket.warning(id, callback)
 	local obj = socket_pool[id]
 	assert(obj)
 	obj.on_warning = callback
+end
+
+function socket.onclose(id, callback)
+	local obj = socket_pool[id]
+	assert(obj)
+	obj.on_close = callback
 end
 
 return socket

--- a/skynet-src/socket_server.c
+++ b/skynet-src/socket_server.c
@@ -1408,69 +1408,14 @@ ctrl_cmd(struct socket_server *ss, struct socket_message *result) {
 	return -1;
 }
 
-struct stream_buffer {
-	char * buf;
-	int sz;
-};
-
-static char *
-reserve_buffer(struct stream_buffer *buffer, int sz) {
-	if (buffer->buf == NULL) {
-		buffer->buf = (char *)MALLOC(sz);
-		return buffer->buf;
-	} else {
-		char * newbuffer = (char *)MALLOC(sz + buffer->sz);
-		memcpy(newbuffer, buffer->buf, buffer->sz);
-		char * ret = newbuffer + buffer->sz;
-		FREE(buffer->buf);
-		buffer->buf = newbuffer;
-		return ret;
-	}
-}
-
-static int
-read_socket(struct socket *s, struct stream_buffer *buffer) {
-	int sz = s->p.size;
-	buffer->buf = NULL;
-	buffer->sz = 0;
-	int rsz = sz;
-	for (;;) {
-		char *buf = reserve_buffer(buffer, rsz);
-		int n = (int)read(s->fd, buf, rsz);
-		if (n <= 0) {
-			if (buffer->sz == 0) {
-				// read nothing
-				FREE(buffer->buf);
-				return n;
-			} else {
-				// ignore the error or hang up, returns buffer
-				// If socket is hang up, SOCKET_CLOSE will be send later.
-				//    (buffer->sz should be 0 next time)
-				break;
-			}
-		}
-		buffer->sz += n;
-		if (n < rsz) {
-			break;
-		}
-		// n == rsz, read again ( and read more )
-		rsz *= 2;
-	}
-	int r = buffer->sz;
-	if (r > sz) {
-		s->p.size = sz * 2;
-	} else if (sz > MIN_READ_BUFFER && r*2 < sz) {
-		s->p.size = sz / 2;
-	}
-	return r;
-}
-
 // return -1 (ignore) when error
 static int
 forward_message_tcp(struct socket_server *ss, struct socket *s, struct socket_lock *l, struct socket_message * result) {
-	struct stream_buffer buf;
-	int n = read_socket(s, &buf);
+	int sz = s->p.size;
+	char * buffer = MALLOC(sz);
+	int n = (int)read(s->fd, buffer, sz);
 	if (n<0) {
+		FREE(buffer);
 		switch(errno) {
 		case EINTR:
 			break;
@@ -1486,6 +1431,7 @@ forward_message_tcp(struct socket_server *ss, struct socket *s, struct socket_lo
 		return -1;
 	}
 	if (n==0) {
+		FREE(buffer);
 		if (s->closing) {
 			// Rare case : if s->closing is true, reading event is disable, and SOCKET_CLOSE is raised.
 			if (nomore_sending_data(s)) {
@@ -1509,7 +1455,7 @@ forward_message_tcp(struct socket_server *ss, struct socket *s, struct socket_lo
 
 	if (halfclose_read(s)) {
 		// discard recv data (Rare case : if socket is HALFCLOSE_READ, reading event is disable.)
-		FREE(buf.buf);
+		FREE(buffer);
 		return -1;
 	}
 
@@ -1518,7 +1464,15 @@ forward_message_tcp(struct socket_server *ss, struct socket *s, struct socket_lo
 	result->opaque = s->opaque;
 	result->id = s->id;
 	result->ud = n;
-	result->data = buf.buf;
+	result->data = buffer;
+
+	if (n == sz) {
+		s->p.size *= 2;
+		return SOCKET_MORE;
+	} else if (sz > MIN_READ_BUFFER && n*2 < sz) {
+		s->p.size /= 2;
+	}
+
 	return SOCKET_DATA;
 }
 
@@ -1757,6 +1711,10 @@ socket_server_poll(struct socket_server *ss, struct socket_message * result, int
 				int type;
 				if (s->protocol == PROTOCOL_TCP) {
 					type = forward_message_tcp(ss, s, &l, result);
+					if (type == SOCKET_MORE) {
+						--ss->event_index;
+						return SOCKET_DATA;
+					}
 				} else {
 					type = forward_message_udp(ss, s, &l, result);
 					if (type == SOCKET_UDP) {

--- a/skynet-src/socket_server.c
+++ b/skynet-src/socket_server.c
@@ -1418,9 +1418,7 @@ forward_message_tcp(struct socket_server *ss, struct socket *s, struct socket_lo
 		FREE(buffer);
 		switch(errno) {
 		case EINTR:
-			break;
 		case AGAIN_WOULDBLOCK:
-			skynet_error(NULL, "socket-server: EAGAIN capture.");
 			break;
 		default:
 			// close when error

--- a/skynet-src/socket_server.h
+++ b/skynet-src/socket_server.h
@@ -13,7 +13,10 @@
 #define SOCKET_EXIT 5
 #define SOCKET_UDP 6
 #define SOCKET_WARNING 7
-#define SOCKET_RST 8 // Only for internal use
+
+// Only for internal use
+#define SOCKET_RST 8
+#define SOCKET_MORE 9
 
 struct socket_server;
 


### PR DESCRIPTION
讨论见 #1358 

如果建立一个连接但长期不使用，目前比较难检测到对端关闭连接。因为只有使用 socket.read 或 socket.block 才能根据返回值知道对端关闭事件。而 socket.read 和 socket.block 不能同时使用，这给 socketchannel 模块监测对端关闭事件造成了困难。

所以增加了 socket.onclose(fd, cb_func) 注册回调函数。

利用这个回调函数，在 socketchannel 的 by_order 模式中，检测 socket close 事件。注： by_session 模式独立线程一直在读 socket ，所以不需要。

一旦 onclose callback 被调用，通过判断 `self.__wait_response` 可以知道 channel 正在等待下一个请求（通道闲置）。此时，再次核对当前的 self.__sock 时候还是注册时的对象（socket channel 因为重连，会更换 self.__sock）；确认后主动 close fd 。

另外，在 `dispatch_by_order` 线程函数中，`pop_response` 之后，`get_response` 之前，都应该检查内部连接是否关闭（`self.__sock` 在关闭后为 false)。避免把 false 当作 sock 对象传给回应处理函数。

这一系列处理可以避免 : sockchannel 的对端主动关闭连接，而我方迟迟不处理关闭事件，而让连接不能完全关闭。

