### PR TITLE
Fix boostrap only support 1 param.

### DIFF
--- a/skynet-src/skynet_start.c
+++ b/skynet-src/skynet_start.c
@@ -235,7 +235,17 @@ bootstrap(struct skynet_context * logger, const char * cmdline) {
 	int sz = strlen(cmdline);
 	char name[sz+1];
 	char args[sz+1];
-	sscanf(cmdline, "%s %s", name, args);
+	int arg_pos;
+	sscanf(cmdline, "%s", name);  
+	arg_pos = strlen(name);
+	if (arg_pos < sz) {
+		while(cmdline[arg_pos] == ' ') {
+			arg_pos++;
+		}
+		strncpy(args, cmdline + arg_pos, sz);
+	} else {
+		args[0] = '\0';
+	}
 	struct skynet_context *ctx = skynet_context_new(name, args);
 	if (ctx == NULL) {
 		skynet_error(NULL, "Bootstrap error : %s\n", cmdline);


### PR DESCRIPTION
在使用gate.so作为boostrap启动的时候，发现boostrap只会读到一个参数传给service_gate, 导致gata服务不能正常启动。
eg: bootstrap: "gate arg1 arg2 arg3".
现在将arg1到字符串结尾到放进args里，而不是仅仅取得arg1.

