### PR TITLE
when skynet.init require the loading module caused circular dependency

### DIFF
--- a/lualib/skynet/require.lua
+++ b/lualib/skynet/require.lua
@@ -43,6 +43,7 @@ do
 
 		local loading_queue = loading[name]
 		if loading_queue then
+			assert(loading_queue.co ~= co, "circular dependency")
 			-- Module is in the init process (require the same mod at the same time in different coroutines) , waiting.
 			local skynet = require "skynet"
 			loading_queue[#loading_queue+1] = co
@@ -54,7 +55,7 @@ do
 			return m
 		end
 
-		loading_queue = {}
+		loading_queue = {co = co}
 		loading[name] = loading_queue
 
 		local old_init_list = context[co]


### PR DESCRIPTION
在 skynet.init 过程中如果 require 了当前模块，目前会一直挂起。因为 skynet.init 认为也是模块加载的一部分，所以这里对这类逻辑 assert 掉，效果同模块级别互相 require 最终也会报错类似。

麻烦云风看看！