### PR TITLE
sharedata 去掉多余的value字段

### DIFF
--- a/service/sharedatad.lua
+++ b/service/sharedatad.lua
@@ -14,7 +14,7 @@ local function newobj(name, tbl)
 	assert(pool[name] == nil)
 	local cobj = sharedata.host.new(tbl)
 	sharedata.host.incref(cobj)
-	local v = { value = tbl , obj = cobj, watch = {} }
+	local v = {obj = cobj, watch = {} }
 	objmap[cobj] = v
 	pool[name] = v
 	pool_count[name] = { n = 0, threshold = 16 }


### PR DESCRIPTION
value字段引用了原来的lua数据表，导致多占用了一定内存