### PR TITLE
Update service_logger.c

### DIFF
--- a/service-src/service_logger.c
+++ b/service-src/service_logger.c
@@ -40,7 +40,7 @@ timestring(struct logger *inst, char tmp[SIZETIMEFMT]) {
 	time_t ti = now/100 + inst->starttime;
 	struct tm info;
 	(void)localtime_r(&ti,&info);
-	strftime(tmp, SIZETIMEFMT, "%D %T", &info);
+	strftime(tmp, SIZETIMEFMT, "%d/%m/%y %H:%M:%S", &info);
 	return now % 100;
 }
 


### PR DESCRIPTION
格式化时间改为通用的结构，修复windows上时间显示不正确问题