### PR TITLE
feat: support http request stream

### DIFF
--- a/lualib/http/httpc.lua
+++ b/lualib/http/httpc.lua
@@ -223,4 +223,12 @@ function httpc.request_stream(method, host, url, recvheader, header, content)
 	return code, body
 end
 
+
+function httpc.close(streamObj)
+	socket.close(streamObj.fd)
+	if streamObj.close then
+		streamObj.close()
+	end
+end
+
 return httpc

--- a/lualib/http/internal.lua
+++ b/lualib/http/internal.lua
@@ -278,8 +278,8 @@ function M.request_stream(fd, interface, method, host, url, recvheader, header, 
 
 		if sz == 0 then
 			local tmpline = {}
-			body = M.recvheader(read, tmpline, streamObj.body)
-			if not body then
+			streamObj.body = M.recvheader(read, tmpline, streamObj.body)
+			if not streamObj.body then
 				return
 			end
 
@@ -292,8 +292,8 @@ function M.request_stream(fd, interface, method, host, url, recvheader, header, 
 		end
 
 		local result
-		if #body >= sz then
-			result = body:sub(1, sz)
+		if #streamObj.body >= sz then
+			result = streamObj.body:sub(1, sz)
 			streamObj.body = streamObj.body:sub(sz+1)
 		else
 			result = streamObj.body .. read(sz - #streamObj.body)

--- a/lualib/http/internal.lua
+++ b/lualib/http/internal.lua
@@ -277,6 +277,13 @@ function M.request_stream(fd, interface, method, host, url, recvheader, header, 
 		end
 
 		if sz == 0 then
+			local tmpline = {}
+			body = M.recvheader(read, tmpline, streamObj.body)
+			if not body then
+				return
+			end
+
+			streamObj.header = M.parseheader(tmpline, 1, streamObj.header)
 			return true
 		end
 
@@ -294,7 +301,7 @@ function M.request_stream(fd, interface, method, host, url, recvheader, header, 
 		end
 
 		streamObj.body = readcrln(read, streamObj.body)
-
+		
 		return result
 	end
 	streamObj.body_reader = chunked_body_reader

--- a/test/testhttp.lua
+++ b/test/testhttp.lua
@@ -25,34 +25,9 @@ local function http_test(protocol)
 	print(status)
 end
 
-local function http_request_stream_test(protocol)
-	print("test request stream")
-	httpc.timeout = 100  -- set timeout 1 second
-	print("GET baidu.com")
-	protocol = protocol or "http"
-	local respheader = {}
-	local host = string.format("%s://baidu.com", protocol)
-	print("geting... ".. host)
-	local status, body = httpc.request_stream("GET", host, "/", respheader)
-	print("[header] =====>")
-	for k,v in pairs(respheader) do
-		print(k,v)
-	end
-	print("[body] =====>", status)
-	print(body)
-
-	local respheader = {}
-	local ip = dns.resolve "baidu.com"
-	print(string.format("GET %s (baidu.com)", ip))
-	local status, body = httpc.get(host, "/", respheader, { host = "baidu.com" })
-	print(status)
-end
-
-
 local function main()
 	dns.server()
 	http_test("http")
-	http_request_stream_test("http")
 
 	if not pcall(require,"ltls.c") then
 		print "No ltls module, https is not supported"

--- a/test/testhttp.lua
+++ b/test/testhttp.lua
@@ -25,10 +25,34 @@ local function http_test(protocol)
 	print(status)
 end
 
+local function http_request_stream_test(protocol)
+	print("test request stream")
+	httpc.timeout = 100  -- set timeout 1 second
+	print("GET baidu.com")
+	protocol = protocol or "http"
+	local respheader = {}
+	local host = string.format("%s://baidu.com", protocol)
+	print("geting... ".. host)
+	local status, body = httpc.request_stream("GET", host, "/", respheader)
+	print("[header] =====>")
+	for k,v in pairs(respheader) do
+		print(k,v)
+	end
+	print("[body] =====>", status)
+	print(body)
+
+	local respheader = {}
+	local ip = dns.resolve "baidu.com"
+	print(string.format("GET %s (baidu.com)", ip))
+	local status, body = httpc.get(host, "/", respheader, { host = "baidu.com" })
+	print(status)
+end
+
 
 local function main()
 	dns.server()
 	http_test("http")
+	http_request_stream_test("http")
 
 	if not pcall(require,"ltls.c") then
 		print "No ltls module, https is not supported"


### PR DESCRIPTION
问题来自 https://github.com/cloudwu/skynet/issues/1461
根据云大的指导在skynet/lualib/http/internal.lua中增加了request_stream方法，**将body数据读取放到流对象的body_reader函数供外部处理**，每次调用body_reader函数时都会获取数据直到流结束或者断开，并且需要自己主动调用`httpc.close(streamObj)`关闭fd；为了减少对已有的影响也在skynet/lualib/http/httpc.lua增加了request_stream方法。
在testhttp中目前测试了 http.request_stream GET请求，测试流的目前不知应该请求哪里，不过我自己测试etcd v3 watch暂时是可以的。
