### PR TITLE
http head method don't need to read body

### DIFF
--- a/lualib/http/httpc.lua
+++ b/lualib/http/httpc.lua
@@ -105,7 +105,7 @@ function httpc.request(method, hostname, url, recvheader, header, content)
 		end)
 	end
 	local ok , statuscode, body , header = pcall(internal.request, interface, method, host, url, recvheader, header, content)
-	if ok then
+	if ok and method:upper() ~= "HEAD" then
 		ok, body = pcall(internal.response, interface, statuscode, body, header)
 	end
 	finish = true


### PR DESCRIPTION
如果[HEAD请求](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Methods/HEAD)响应包含 Content-Length，正常情况不应该依赖这个值去读取BODY，比如使用阿里云的这个[API](https://help.aliyun.com/document_detail/31984.html) 。