### PR TITLE
fix #1494 socket read阻塞问题

### DIFF
--- a/lualib/http/tlshelper.lua
+++ b/lualib/http/tlshelper.lua
@@ -43,14 +43,16 @@ function tlshelper.closefunc(tls_ctx)
 end
 
 function tlshelper.readfunc(fd, tls_ctx)
-    local readfunc = socket.readfunc(fd)
-    local read_buff = false
+    local function readfunc()
+        readfunc = socket.readfunc(fd)
+        return ""
+    end
+    local read_buff = ""
     return function (sz)
-        read_buff = read_buff or tls_ctx:read()
         if not sz then
             local s = ""
             if #read_buff == 0 then
-                local ds = readfunc(sz)
+                local ds = readfunc()
                 s = tls_ctx:read(ds)
             end
             s = read_buff .. s


### PR DESCRIPTION
在socket init 时执行`init_responsefunc` 时，有可能会导致后面的header也收到了，所以在后续的`readfunc` 中第一次要从tls中读取下数据再尝试去从socket 读，避免阻塞。