### PR TITLE
panic while reading from stdin

### DIFF
--- a/3rd/lua/lauxlib.c
+++ b/3rd/lua/lauxlib.c
@@ -1221,7 +1221,7 @@ static int cache_mode(lua_State *L) {
 LUALIB_API int luaL_loadfilex (lua_State *L, const char *filename,
                                              const char *mode) {
   int level = cache_level(L);
-  if (level == CACHE_OFF) {
+  if (level == CACHE_OFF || filename == NULL) {
     return luaL_loadfilex_(L, filename, mode);
   }
   const void * proto = load_proto(filename);


### PR DESCRIPTION
在使用 `codecache` 并且后台启动的情况下，`loadfile(nil)` 会触发 `save_proto(NULL, proto)`，此时出错后会直接 `panic`。

处理 `filename` 为 `NULL` 的情况，不做 `cache` 的处理。