### PR TITLE
feat: add sharetable queryall

### DIFF
--- a/lualib/skynet/sharetable.lua
+++ b/lualib/skynet/sharetable.lua
@@ -92,6 +92,16 @@ local function sharetable_service()
 		skynet.ret(skynet.pack(ptr))
 	end
 
+    function sharetable.queryall(source, filenamelist)
+        local ptrList = {}
+        for _, filename in ipairs(filenamelist) do
+            if files[filename] then
+                ptrList[filename] = query_file(source, filename)
+            end
+        end
+        skynet.ret(skynet.pack(ptrList))
+    end
+
 	function sharetable.close(source)
 		local list = clients[source]
 		if list then
@@ -208,6 +218,21 @@ function sharetable.query(filename)
 	end
 end
 
+function sharetable.queryall(filenamelist)
+    local list, t, map = {}
+    local ptrList = skynet.call(sharetable.address, "lua", "queryall", filenamelist)
+    for filename, ptr in pairs(ptrList) do
+        t = core.clone(ptr)
+        map = RECORD[filename]
+        if not map then
+            map = {}
+            RECORD[filename] = map
+        end
+        map[t] = true
+        list[filename] = t
+    end
+    return list
+end
 
 local pairs = pairs
 local type = type

--- a/test/testsharetable.lua
+++ b/test/testsharetable.lua
@@ -1,6 +1,17 @@
 local skynet = require "skynet"
 local sharetable = require "skynet.sharetable"
 
+local function queryall_test()
+	sharetable.loadtable("test_one", {["message"] = "hello one", x = 1, 1})
+	sharetable.loadtable("test_two", {["message"] = "hello two", x = 2, 2})
+	local list = sharetable.queryall({"test_one", "test_two"})
+	for filename, tbl in pairs(list) do
+		for k, v in pairs(tbl) do
+			print(filename, k, v)
+		end
+	end
+end
+
 skynet.start(function()
 	-- You can also use sharetable.loadfile / sharetable.loadstring
 	sharetable.loadtable ("test", { x=1,y={ 'hello world' },['hello world'] = true })
@@ -13,4 +24,6 @@ skynet.start(function()
 	for k,v in pairs(t) do
 		print(k,v)
 	end
+
+	queryall_test()
 end)


### PR DESCRIPTION
支持批量获取配置指针。
测试效果如下:
```
[root@f3e91cf322aa skynet]# ./skynet examples/config
[:01000002] LAUNCH snlua bootstrap
[:01000003] LAUNCH snlua launcher
[:01000004] LAUNCH snlua cmaster
[:01000004] master listen socket 0.0.0.0:2013
[:01000005] LAUNCH snlua cslave
[:01000005] slave connect to master 127.0.0.1:2013
[:01000004] connect from 127.0.0.1:34610 4
[:01000006] LAUNCH harbor 1 16777221
[:01000004] Harbor 1 (fd=4) report 127.0.0.1:2526
[:01000005] Waiting for 0 harbors
[:01000005] Shakehand ready
[:01000007] LAUNCH snlua datacenterd
[:01000008] LAUNCH snlua service_mgr
[:01000009] LAUNCH snlua testsharetable
[:0100000a] LAUNCH snlua service_provider
[:0100000b] LAUNCH snlua service_cell sharetable
y	table: 0x7f9156646280
hello world	true
x	1
1	1
2	2
3	3
test_two	1	2
test_two	message	hello two
test_two	x	2
test_one	1	1
test_one	message	hello one
test_one	x	1
[:01000002] KILL self
```