### PR TITLE
perf: add sharetable queryall default behavior(all share data)

### DIFF
--- a/lualib/skynet/sharetable.lua
+++ b/lualib/skynet/sharetable.lua
@@ -92,13 +92,27 @@ local function sharetable_service()
 		skynet.ret(skynet.pack(ptr))
 	end
 
-    function sharetable.queryall(source, filenamelist)
-        local ptrList = {}
+	local function querylist(source, filenamelist)
+		local ptrList = {}
         for _, filename in ipairs(filenamelist) do
             if files[filename] then
                 ptrList[filename] = query_file(source, filename)
             end
         end
+		return ptrList
+	end
+
+	local function queryall(source)
+		local ptrList = {}
+		for filename in pairs(files) do
+			ptrList[filename] = query_file(source, filename)
+		end
+		return ptrList
+	end
+
+    function sharetable.queryall(source, filenamelist)
+		local queryFunc = filenamelist and querylist or queryall
+		local ptrList = queryFunc(source, filenamelist)
         skynet.ret(skynet.pack(ptrList))
     end
 

--- a/test/testsharetable.lua
+++ b/test/testsharetable.lua
@@ -4,8 +4,17 @@ local sharetable = require "skynet.sharetable"
 local function queryall_test()
 	sharetable.loadtable("test_one", {["message"] = "hello one", x = 1, 1})
 	sharetable.loadtable("test_two", {["message"] = "hello two", x = 2, 2})
+	sharetable.loadtable("test_three", {["message"] = "hello three", x = 3, 3})
 	local list = sharetable.queryall({"test_one", "test_two"})
 	for filename, tbl in pairs(list) do
+		for k, v in pairs(tbl) do
+			print(filename, k, v)
+		end
+	end
+
+	print("test queryall default")
+	local defaultlist = sharetable.queryall()
+	for filename, tbl in pairs(defaultlist) do
 		for k, v in pairs(tbl) do
 			print(filename, k, v)
 		end


### PR DESCRIPTION
建议接受可空参数 返回所有

_Originally posted by @sniper00 in https://github.com/cloudwu/skynet/issues/1536#issuecomment-1040309038_

测试效果如下：
~~~
[root@f3e91cf322aa skynet]# ./skynet examples/config
[:01000002] LAUNCH snlua bootstrap
[:01000003] LAUNCH snlua launcher
[:01000004] LAUNCH snlua cmaster
[:01000004] master listen socket 0.0.0.0:2013
[:01000005] LAUNCH snlua cslave
[:01000005] slave connect to master 127.0.0.1:2013
[:01000004] connect from 127.0.0.1:34632 4
[:01000006] LAUNCH harbor 1 16777221
[:01000004] Harbor 1 (fd=4) report 127.0.0.1:2526
[:01000005] Waiting for 0 harbors
[:01000005] Shakehand ready
[:01000007] LAUNCH snlua datacenterd
[:01000008] LAUNCH snlua service_mgr
[:01000009] LAUNCH snlua testsharetable
[:0100000a] LAUNCH snlua service_provider
[:0100000b] LAUNCH snlua service_cell sharetable
y	table: 0x7f8b88314900
hello world	true
x	1
1	1
2	2
3	3
test_one	1	1
test_one	message	hello one
test_one	x	1
test_two	1	2
test_two	message	hello two
test_two	x	2
test queryall default
test	1	1
test	2	2
test	3	3
test_one	1	1
test_one	message	hello one
test_one	x	1
test_two	1	2
test_two	message	hello two
test_two	x	2
test_three	1	3
test_three	message	hello three
test_three	x	3
~~~