### PR TITLE
Update websocket.lua

### DIFF
--- a/lualib/http/websocket.lua
+++ b/lualib/http/websocket.lua
@@ -518,5 +518,9 @@ function M.close(id, code ,reason)
     end
 end
 
+function M.isclosed(id)
+    return _isws_closed(id)	
+end
+
 
 return M


### PR DESCRIPTION
外部其他服务的执行流可能会执行一些阻塞操作，等唤醒继续执行流时，相关的socket_id可能已经被其他执行流关闭了，但当前执行流继续自己的逻辑给这个socket_id发送“M.write”消息时，根据目前的“M.write”的逻辑（“local ws_obj = assert(ws_pool[id])”）来看会抛出异常，虽然上层我可以用（pcall）去调用“M.write”方法，但我觉得这种情况下不应该当做“异常”来处理（使用pcall我认为通常是用于捕获一些无法预期的不合理的问题），这种情况是我能预期的合理问题，用pcall不够优雅。我希望“websocket”模块能提供一个查询“socket_id”是否已经关闭的接口，方便外部可选择性的灵活使用，所以特提议本次修改。