### PR TITLE
feat: add cluster.unregister

### DIFF
--- a/examples/cluster1.lua
+++ b/examples/cluster1.lua
@@ -12,6 +12,8 @@ skynet.start(function()
 	-- register name "sdb" for simpledb, you can use cluster.query() later.
 	-- See cluster2.lua
 	cluster.register("sdb", sdb)
+	cluster.unregister("sdb")
+	cluster.register("sdb", sdb)
 
 	print(skynet.call(sdb, "lua", "SET", "a", "foobar"))
 	print(skynet.call(sdb, "lua", "SET", "b", "foobar2"))

--- a/lualib/skynet/cluster.lua
+++ b/lualib/skynet/cluster.lua
@@ -106,6 +106,11 @@ function cluster.register(name, addr)
 	return skynet.call(clusterd, "lua", "register", name, addr)
 end
 
+function cluster.unregister(name)
+	assert(type(name) == "string")
+	return skynet.call(clusterd, "lua", "unregister", name)
+end
+
 function cluster.query(node, name)
 	return skynet.call(get_sender(node), "lua", "req", 0, skynet.pack(name))
 end

--- a/service/clusterd.lua
+++ b/service/clusterd.lua
@@ -204,6 +204,18 @@ function command.register(source, name, addr)
 	skynet.error(string.format("Register [%s] :%08x", name, addr))
 end
 
+function command.unregister(_, name)
+	if not register_name[name] then
+		return skynet.ret(nil)
+	end
+	local addr = register_name[name]
+	register_name[addr] = nil
+	register_name[name] = nil
+	clearnamecache()
+	skynet.ret(nil)
+	skynet.error(string.format("Unregister [%s] :%08x", name, addr))
+end
+
 function command.queryname(source, name)
 	skynet.ret(skynet.pack(register_name[name]))
 end


### PR DESCRIPTION
当前我们一些服务需要关闭然后重启，当前命名主要采用的是**服务名称_服id_模块id**，所以需要解决cluster.register注册冲突问题。
之前一些服务使用的方案是拼一个递增的序列，然后使用方调用一次接口获取一下服务名称也可避免这个问题。
不是那么方便所以想支持直接取消注册然后重新注册。