### PR TITLE
Fix handle register when slot[0] is null will segmentation fault

### DIFF
--- a/examples/config.handle
+++ b/examples/config.handle
@@ -1,0 +1,10 @@
+include "config.path"
+
+thread = 8
+logger = "skynet.log"
+logpath = "."
+harbor = 0
+start = "testhandle"	-- main script
+bootstrap = "snlua bootstrap"	-- The service for bootstrap
+cpath = root.."cservice/?.so"
+--daemon = "./skynet.pid"

--- a/skynet-src/skynet_handle.c
+++ b/skynet-src/skynet_handle.c
@@ -60,9 +60,11 @@ skynet_handle_register(struct skynet_context *ctx) {
 		struct skynet_context ** new_slot = skynet_malloc(s->slot_size * 2 * sizeof(struct skynet_context *));
 		memset(new_slot, 0, s->slot_size * 2 * sizeof(struct skynet_context *));
 		for (i=0;i<s->slot_size;i++) {
-			int hash = skynet_context_handle(s->slot[i]) & (s->slot_size * 2 - 1);
-			assert(new_slot[hash] == NULL);
-			new_slot[hash] = s->slot[i];
+			if (s->slot[i]) {
+				int hash = skynet_context_handle(s->slot[i]) & (s->slot_size * 2 - 1);
+				assert(new_slot[hash] == NULL);
+				new_slot[hash] = s->slot[i];
+			}
 		}
 		skynet_free(s->slot);
 		s->slot = new_slot;

--- a/test/testhandle.lua
+++ b/test/testhandle.lua
@@ -1,0 +1,33 @@
+local skynet = require "skynet"
+require "skynet.manager"
+
+local mod = ...
+if mod == "slave" then
+
+skynet.start(function()
+    skynet.error("addr:", skynet.self())
+end)
+
+else
+
+skynet.start(function()
+	skynet.newservice("debug_console",8000)
+	skynet.error("master addr:", skynet.self())
+
+    skynet.newservice("testhandle", "slave")
+    skynet.newservice("testhandle", "slave")
+    skynet.newservice("testhandle", "slave")
+    skynet.newservice("testhandle", "slave")
+    skynet.newservice("testhandle", "slave")
+    skynet.newservice("testhandle", "slave")
+
+    while true do
+        local addr = skynet.newservice("testhandle", "slave")
+        skynet.kill(addr)
+        if addr > 0xfffff0 then
+            break
+        end
+    end
+end)
+
+end


### PR DESCRIPTION
使用旧代码可以重现： `./skynet examples/config.handle`

原因是当 s->slot[0] 为 NULL 时，即 context 为 NULL，对 NULL 取 handle 值会崩溃。需要构造出 slot[0] 为空，其他值都不空，且 handle_index 处于 (HANDLE_MASK - slot_size, HANDLE_MASK] 范围内时注册新服务。

这个 bug 是一位群友发现的，我只是写了个找到不修改 HANDLE_MASK 值来重现的测试用例，附件是群友的分析。
[handle的分析.md](https://github.com/cloudwu/skynet/files/8481336/handle.md)

