### PR TITLE
bugfix: mongo getMore command field batchSize cannot replace with limit

### DIFF
--- a/lualib/skynet/db/mongo.lua
+++ b/lualib/skynet/db/mongo.lua
@@ -690,7 +690,7 @@ function mongo_cursor:hasNext()
 		else
 			if self.__cursor  and self.__cursor > 0 then
 				local name = self.__collection.name
-				response = database:runCommand("getMore", bson_int64(self.__cursor), "collection", name, "batchSize", self.__limit)
+				response = database:runCommand("getMore", bson_int64(self.__cursor), "collection", name)
 			else
 				-- no more
 				self.__document	= nil


### PR DESCRIPTION
getMore命令的可选字段batchSize的值必须是正整数，语义是每次批量返回文档数量。
cursor.limit方法的参数范围是 -2^31到 2^31，语义是返回的最大总文档数量。
两者不应该混用。