### PR TITLE
修复client_number计数错误

### DIFF
--- a/lualib/snax/gateserver.lua
+++ b/lualib/snax/gateserver.lua
@@ -90,6 +90,7 @@ function gateserver.start(handler)
 	MSG.more = dispatch_queue
 
 	function MSG.open(fd, msg)
+		client_number = client_number + 1
 		if client_number >= maxclient then
 			socketdriver.shutdown(fd)
 			return
@@ -98,7 +99,6 @@ function gateserver.start(handler)
 			socketdriver.nodelay(fd)
 		end
 		connection[fd] = true
-		client_number = client_number + 1
 		handler.connect(fd, msg)
 	end
 


### PR DESCRIPTION
在`MSG.open`中，当`client_number >= maxclient`时，连接被关闭后触发`MSG.close`，导致`client_number`没有`+1`的情况下被`-1`