### PR TITLE
 为cluster.open添加maxclient参数

### DIFF
--- a/lualib/skynet/cluster.lua
+++ b/lualib/skynet/cluster.lua
@@ -75,11 +75,11 @@ function cluster.send(node, address, ...)
 	end
 end
 
-function cluster.open(port)
+function cluster.open(port, maxclient)
 	if type(port) == "string" then
-		return skynet.call(clusterd, "lua", "listen", port)
+		return skynet.call(clusterd, "lua", "listen", port, nil, maxclient)
 	else
-		return skynet.call(clusterd, "lua", "listen", "0.0.0.0", port)
+		return skynet.call(clusterd, "lua", "listen", "0.0.0.0", port, maxclient)
 	end
 end
 

--- a/service/clusterd.lua
+++ b/service/clusterd.lua
@@ -142,17 +142,17 @@ function command.reload(source, config)
 	skynet.ret(skynet.pack(nil))
 end
 
-function command.listen(source, addr, port)
+function command.listen(source, addr, port, maxclient)
 	local gate = skynet.newservice("gate")
 	if port == nil then
 		local address = assert(node_address[addr], addr .. " is down")
 		addr, port = string.match(address, "(.+):([^:]+)$")
 		port = tonumber(port)
 		assert(port ~= 0)
-		skynet.call(gate, "lua", "open", { address = addr, port = port })
+		skynet.call(gate, "lua", "open", { address = addr, port = port, maxclient = maxclient })
 		skynet.ret(skynet.pack(addr, port))
 	else
-		local realaddr, realport = skynet.call(gate, "lua", "open", { address = addr, port = port })
+		local realaddr, realport = skynet.call(gate, "lua", "open", { address = addr, port = port, maxclient = maxclient })
 		skynet.ret(skynet.pack(realaddr, realport))
 	end
 end


### PR DESCRIPTION
`cluster`启动的`gate`没有传入`maxclient`参数，导致默认连接数限制在`1024`。