### PR TITLE
修改bson.encode 判断 is_rawarray err

### DIFF
--- a/lualib-src/lua-bson.c
+++ b/lualib-src/lua-bson.c
@@ -522,7 +522,7 @@ is_rawarray(lua_State *L) {
 	if (firstkey <= 1) {
 		return firstkey > 0;
 	}
-	return firstkey <= lua_rawlen(L, -1);
+	return firstkey <= lua_rawlen(L, -1) && lua_rawlen(L, -1);
 }
 
 static void


### PR DESCRIPTION
encode tbl时, tbl形如： {[3] = 0},会将tbl错误的识别为 array 导致error(Bson dictionary's key can't be number) 无法正常抛出

在不增加复杂度的情况下 使用rawlen(L, -1) double check 判断一下数组长度是否 非0 

当然如果畸形tbl为 {1，2， [4] = 0}
encode仍然会返回错误的数据{1,2};  