### PR TITLE
修复设置 callback导致的crash问题

### DIFF
--- a/lualib-src/lua-skynet.c
+++ b/lualib-src/lua-skynet.c
@@ -96,28 +96,27 @@ forward_cb(struct skynet_context * context, void * ud, int type, int session, ui
 
 static void
 clear_last_context(lua_State *L) {
-  if (lua_getfield(L, LUA_REGISTRYINDEX, "callback_context") == LUA_TUSERDATA) {
-    lua_pushnil(L);
-    lua_setiuservalue(L, -2, 2);
-  }
-  lua_pop(L, 1);
+	if (lua_getfield(L, LUA_REGISTRYINDEX, "callback_context") == LUA_TUSERDATA) {
+		lua_pushnil(L);
+		lua_setiuservalue(L, -2, 2);
+	}
+	lua_pop(L, 1);
 }
 
 static int
 _cb_pre(struct skynet_context * context, void * ud, int type, int session, uint32_t source, const void * msg, size_t sz) {
-    struct callback_context *cb_ctx = (struct callback_context *)ud;
-    clear_last_context(cb_ctx->L);
-    skynet_callback(context, ud, _cb);
-    return _cb(context, cb_ctx, type, session, source, msg, sz);
+	struct callback_context *cb_ctx = (struct callback_context *)ud;
+	clear_last_context(cb_ctx->L);
+	skynet_callback(context, ud, _cb);
+	return _cb(context, cb_ctx, type, session, source, msg, sz);
 }
 
 static int
-_forward_pre(struct skynet_context *context, void *ud, int type, int session, uint32_t source, const void *msg, size_t sz)
-{
-    struct callback_context *cb_ctx = (struct callback_context *)ud;
-    clear_last_context(cb_ctx->L);
-    skynet_callback(context, ud, forward_cb);
-    return forward_cb(context, cb_ctx, type, session, source, msg, sz);
+_forward_pre(struct skynet_context *context, void *ud, int type, int session, uint32_t source, const void *msg, size_t sz) {
+	struct callback_context *cb_ctx = (struct callback_context *)ud;
+	clear_last_context(cb_ctx->L);
+	skynet_callback(context, ud, forward_cb);
+	return forward_cb(context, cb_ctx, type, session, source, msg, sz);
 }
 
 static int

--- a/lualib-src/lua-skynet.c
+++ b/lualib-src/lua-skynet.c
@@ -50,12 +50,6 @@ struct callback_context {
 	lua_State *L;
 };
 
-struct precb_context {
-	struct callback_context *cb_ctx;
-	int forward;
-};
-
-
 static int
 _cb(struct skynet_context * context, void * ud, int type, int session, uint32_t source, const void * msg, size_t sz) {
 	struct callback_context *cb_ctx = (struct callback_context *)ud;
@@ -141,11 +135,7 @@ lcallback(lua_State *L) {
 	lua_setfield(L, LUA_REGISTRYINDEX, "callback_context");
 	lua_xmove(L, cb_ctx->L, 1);
 
-    if(forward) {
-        skynet_callback(context, cb_ctx, _forward_pre);
-    } else {
-        skynet_callback(context, cb_ctx, _cb_pre);
-    }
+	skynet_callback(context, cb_ctx, (forward)?(_forward_pre):(_cb_pre));
 	return 0;
 }
 

--- a/lualib-src/lua-skynet.c
+++ b/lualib-src/lua-skynet.c
@@ -101,7 +101,7 @@ forward_cb(struct skynet_context * context, void * ud, int type, int session, ui
 static int
 lcallback(lua_State *L) {
 	struct callback_context *cb_ctx = NULL;
-	// save calling coroutine
+	// save calling callback context
 	do {
 		if(lua_getfield(L, LUA_REGISTRYINDEX, "callback_context") == LUA_TUSERDATA) {
 			cb_ctx = lua_touserdata(L, -1);


### PR DESCRIPTION
### 使用以下测试用例:
~~~.lua
local function test_crash_service()
        local c = require "skynet.core"
        print("test_crash_service start..")
        c.callback(function () end)
        c.callback(function () end)
        print("test_crash_service finished")
        collectgarbage "collect"
end
local Service = require "skynet.service"
Service.new("test_crash_service", test_crash_service)
~~~
被执行后将会出现`segmentation fault`，导致crash。

### 问题原因：
因为调用`lcallback` 时会创建新的`coroutine` ，来处理后续的回调函数。但如果该函数是在被`_cb` 中触发的话，会导致当前正在被使用的`cb_ctx` 失去被`callback_context` key持有的引用。此时如果再触发gc行为，将会导致当前正在被执行的`coroutine` 和 `cb_ctx` 被回收掉，从而导致crash。

### 解决方法：
对`struct callback_context` 结构添加`bool calling` 字段，表示当前`_cb` 正在被执行中，在调用`lcallback`时 会判断`calling`, 如果该`cb_ctx`正在被调用执行， 将会被`last_callback_context` 所持有，从而避免被gc回收。
