### PR TITLE
task接口添加count参数

### DIFF
--- a/lualib/skynet/debug.lua
+++ b/lualib/skynet/debug.lua
@@ -55,18 +55,19 @@ local function init(skynet, export)
 			end
 		end
 
-		function dbgcmd.TASK(session)
+		function dbgcmd.TASK(session, count)
 			if session then
 				skynet.ret(skynet.pack(skynet.task(session)))
 			else
 				local task = {}
+				task.count = count
 				skynet.task(task)
 				skynet.ret(skynet.pack(task))
 			end
 		end
 
-		function dbgcmd.UNIQTASK()
-			skynet.ret(skynet.pack(skynet.uniqtask()))
+		function dbgcmd.UNIQTASK(count)
+			skynet.ret(skynet.pack(skynet.uniqtask(count)))
 		end
 
 		function dbgcmd.INFO(...)


### PR DESCRIPTION
当挂起的协程数过大时，有以下问题
1. task与uniqtask遍历需要花费很长的时间。
2. skynet.ret(skynet.pack(task))返回的时间也需要很久。
所以希望增加一个count参数限制数据量