### PR TITLE
websocket添加is_close方法

### DIFF
--- a/lualib/http/websocket.lua
+++ b/lualib/http/websocket.lua
@@ -9,6 +9,15 @@ local socket_error = sockethelper.socket_error
 local GLOBAL_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 local MAX_FRAME_SIZE = 256 * 1024 -- max frame is 256K
 
+local assert = assert
+local pairs = pairs
+local error = error
+local string = string
+local xpcall = xpcall
+local debug = debug
+local table = table
+local tonumber = tonumber
+
 local M = {}
 
 
@@ -526,5 +535,8 @@ function M.close(id, code ,reason)
     end
 end
 
+function M.is_close(id)
+	return _isws_closed(id)
+end
 
 return M

--- a/lualib/http/websocket.lua
+++ b/lualib/http/websocket.lua
@@ -535,8 +535,6 @@ function M.close(id, code ,reason)
     end
 end
 
-function M.is_close(id)
-	return _isws_closed(id)
-end
+M.is_close = _isws_closed
 
 return M


### PR DESCRIPTION
调用`websocket.write`会因为`ws_pool`已经没有而断言，想用`is_close`做`write`的前置判断，`socket.invalid` 和 `socket.disconnected` 并不能做到。
