### PR TITLE
避免 sharedata 误用大于32位数字做 key 时,可能导致程序崩溃

### DIFF
--- a/lualib-src/lua-sharedata.c
+++ b/lualib-src/lua-sharedata.c
@@ -306,6 +306,7 @@ convtable(lua_State *L) {
 		for (i=0;i<sizehash;i++) {
 			tbl->hash[i].valuetype = VALUETYPE_NIL;
 			tbl->hash[i].nocolliding = 0;
+			tbl->hash[i].next = -1;
 		}
 		tbl->sizehash = sizehash;
 


### PR DESCRIPTION
```
local skynet = require "skynet"
require "skynet.manager"
local sharedata = require 'skynet.sharedata'

skynet.init(function()
    local int32 = 123
    local int64 = (1 << 32) + 123
    local data = {
        [int32] = 1,
        [int64] = 2,
        -- test = 3,
    }
    sharedata.new("test", data)
end)

skynet.start(function()
    local data = sharedata.query("test")
    print(data[2])
    skynet.abort()
end)
```
误用大于32位的数字做 key, 有极少概率导致严重问题。
如上这段代码可以导致进程死循环或者崩溃