### PR TITLE
add get_sender function to outside

### DIFF
--- a/lualib/skynet/cluster.lua
+++ b/lualib/skynet/cluster.lua
@@ -55,9 +55,7 @@ local function get_sender(node)
 	return s
 end
 
-function cluster.get_sender(node)
-	return get_sender(node)
-end
+cluster.get_sender = get_sender
 
 function cluster.call(node, address, ...)
 	-- skynet.pack(...) will free by cluster.core.packrequest


### PR DESCRIPTION
目的是用sender结合skynet.select的超时特性，实现一个超时的cluster.call，所以希望这里能够把get_sender的接口加上