### PR TITLE
fix: 当 mysql 数据库日期类型(timestamp, datetime)的字段，数据值没有 "时间部分（时分秒）" 时，比如 "…

### DIFF
--- a/lualib/skynet/db/mysql.lua
+++ b/lualib/skynet/db/mysql.lua
@@ -841,6 +841,9 @@ local function _get_datetime(data, pos)
     if len == 7 then
         year, month, day, hour, minute, second, pos = string.unpack("<I2BBBBB", data, pos)
         value = strformat("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second)
+    elseif len == 4 then
+        year, month, day, pos = string.unpack("<I2BB", data, pos)
+        value = strformat("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, 0, 0, 0)
     else
         value = "2017-09-09 20:08:09"
         --unsupported format


### PR DESCRIPTION
当mysql数据库时间(timestamp, datetime)数据类型没有 "时分秒" 或 "时分秒" 为 0 时，例如 "2021-12-10 00:00:00"。

数据的长度是4(年2，月1， 日1)，
而不是预期的7(年2，月1， 日1， 时1， 分1， 秒1)

![image](https://github.com/cloudwu/skynet/assets/5662644/99208ad6-e136-4152-aa0e-286c1f04c08f)
