### PR TITLE
session或者source为0时不回消息

### DIFF
--- a/lualib/skynet.lua
+++ b/lualib/skynet.lua
@@ -653,7 +653,9 @@ function skynet.exit()
 		c.send(address, skynet.PTYPE_ERROR, 0, "")
 	end
 	c.callback(function(prototype, msg, sz, session, source)
-		c.send(source, skynet.PTYPE_ERROR, session, "")
+		if session ~= 0 and source ~= 0 then
+			c.send(source, skynet.PTYPE_ERROR, session, "")
+		end
 	end)
 	c.command("EXIT")
 	-- quit service


### PR DESCRIPTION
当处理同时多条消息时，假如第一条是skynet.exit，后面有timeout的消息(source = 0)，就会导致报错 Invalid service address 0

skynet.exit 会替换 callback函数，source = 0时使用c.send发送消息报错