### PR TITLE
skynet使用原生error，防止给替换

### DIFF
--- a/lualib/skynet.lua
+++ b/lualib/skynet.lua
@@ -4,6 +4,7 @@ local skynet_require = require "skynet.require"
 local tostring = tostring
 local coroutine = coroutine
 local assert = assert
+local error = error
 local pairs = pairs
 local pcall = pcall
 local table = table


### PR DESCRIPTION
我们项目中定制了error，但是不希望skynet error使用我们定制的error。 看到assert有提前记下来，就想补个error的