### PR TITLE
fix *** buffer overflow detected *** problem with gcc-13+ or -D_FORTIFY_SOURCE=3

### DIFF
--- a/skynet-src/skynet_env.c
+++ b/skynet-src/skynet_env.c
@@ -11,42 +11,39 @@
 struct skynet_env {
 	struct spinlock lock;
 	lua_State *L;
-};
+} E;
 
-static struct skynet_env *E = NULL;
-
-const char * 
+const char *
 skynet_getenv(const char *key) {
-	SPIN_LOCK(E)
+	SPIN_LOCK(&E)
 
-	lua_State *L = E->L;
-	
+	lua_State *L = E.L;
+
 	lua_getglobal(L, key);
 	const char * result = lua_tostring(L, -1);
 	lua_pop(L, 1);
 
-	SPIN_UNLOCK(E)
+	SPIN_UNLOCK(&E)
 
 	return result;
 }
 
-void 
+void
 skynet_setenv(const char *key, const char *value) {
-	SPIN_LOCK(E)
-	
-	lua_State *L = E->L;
+	SPIN_LOCK(&E)
+
+	lua_State *L = E.L;
 	lua_getglobal(L, key);
 	assert(lua_isnil(L, -1));
 	lua_pop(L,1);
 	lua_pushstring(L,value);
 	lua_setglobal(L,key);
 
-	SPIN_UNLOCK(E)
+	SPIN_UNLOCK(&E)
 }
 
 void
 skynet_env_init() {
-	E = skynet_malloc(sizeof(*E));
-	SPIN_INIT(E)
-	E->L = luaL_newstate();
+	SPIN_INIT(&E)
+	E.L = luaL_newstate();
 }


### PR DESCRIPTION
gcc-13 及以上版本会默认开启 -D_FORTIFY_SOURCE=3 (原配置为 -D_FORTIFY_SOURCE=2), 在开启 O1 以上编译优化的时候编译器可能对 memcpy 插入检查, 发生越界误判 (malloc_usable_size(ptr) 返回的大小要大于实际 malloc 大小)

崩溃堆栈:
![image](https://github.com/cloudwu/skynet/assets/34877029/c1935201-d5f9-4169-853e-d31ee27d0e80)

最小复现代码:
```C
// test.c

#include <malloc.h>
#include <stdint.h>
#include <string.h>

size_t size = 32;

struct mem_cookie {
	uint32_t handle;
};

int main(void) {
    void *ptr = malloc (size);
    size_t usable_size = malloc_usable_size(ptr); // bigger than size

    struct mem_cookie *p = ptr + usable_size - sizeof(struct mem_cookie);

    uint32_t handle = 1234;
    printf("size:%lu usable_size:%lu p:%p\n", size, usable_size, p);

    // *** buffer overflow detected ***: terminated
    memcpy(&p->handle, &handle, sizeof(handle));
    printf("handle %d\n", p->handle);
    return 0;
}
```

编译方式:
```
gcc-13 -O2 -o test test.c
```
或者
```
clang -O2 -o test test.c -D_FORTIFY_SOURCE=3
```

相关: https://bugs.launchpad.net/ubuntu/+source/gcc-13/+bug/2012440