### PR TITLE
Config 文件支持使用 lua 标准库

### DIFF
--- a/skynet-src/skynet_main.c
+++ b/skynet-src/skynet_main.c
@@ -84,11 +84,11 @@ int sigign() {
 }
 
 static const char * load_config = "\
-	local result = {}\n\
+	local result = setmetatable({}, { __index = _G })\n\
 	local function getenv(name) return assert(os.getenv(name), [[os.getenv() failed: ]] .. name) end\n\
 	local sep = package.config:sub(1,1)\n\
 	local current_path = [[.]]..sep\n\
-	local function include(filename)\n\
+	function include(filename)\n\
 		local last_path = current_path\n\
 		local path, name = filename:match([[(.*]]..sep..[[)(.*)$]])\n\
 		if path then\n\
@@ -107,10 +107,9 @@ static const char * load_config = "\
 		assert(load(code,[[@]]..filename,[[t]],result))()\n\
 		current_path = last_path\n\
 	end\n\
-	setmetatable(result, { __index = { include = include } })\n\
 	local config_name = ...\n\
 	include(config_name)\n\
-	setmetatable(result, nil)\n\
+	include = nil\n\
 	return result\n\
 ";
 


### PR DESCRIPTION
当项目比较大，目录比较多时，在 Config 文件里使用 `..` 连接路径显得不太优雅，也容易写错：

```lua
lua_path = "src/a3/common/?.lua;" ..
    "src/common/Config/?.lua;" ..
    "src/common/Define/?.lua;" ..
    "src/common/Define/ApiGateway/?.lua;" ..
    "src/common/Lualib/?.lua;" ..
    "src/common/Lualib/Utilities/?.lua;" ..
    "src/common/Service/?.lua;" ..
    ...
```

把路径封到一张表里，然后使用 `table.concat` 连接起来会好一些：
```lua
lua_path = table.concat({
    "src/a3/common/?.lua",
    "src/common/Config/?.lua",
    "src/common/Define/?.lua",
    "src/common/Define/ApiGateway/?.lua",
    "src/common/Lualib/?.lua",
    "src/common/Lualib/Utilities/?.lua",
    "src/common/Service/?.lua",
    ...
}, ";")
```

但是目前的 skynet 是不支持在 Config 文件里使用 `table.concat` 的，会报 `attempt to index a nil value (global 'table')` 错误。

原因是使用 `load` 加载 Config 文件时传入一个空的全局环境，替换了 `_G`

```
local result = {}
load(code,[[@]]..filename,[[t]],result)
```

本次 PR 做出以下修改，使 Config 内能访问到 _G 的内容

```
local result = setmetatable({}, { __index = _G })
```