### PR TITLE
fix socketchannel mem leakage

### DIFF
--- a/lualib/skynet/socketchannel.lua
+++ b/lualib/skynet/socketchannel.lua
@@ -60,6 +60,10 @@ local function close_channel_socket(self)
 	if self.__sock then
 		local so = self.__sock
 		self.__sock = false
+		if self.__wait_response then
+			skynet.wakeup(self.__wait_response)
+			self.__wait_response = nil
+		end
 		-- never raise error
 		pcall(socket.close,so[1])
 	end
@@ -128,7 +132,7 @@ local function dispatch_by_session(self)
 end
 
 local function pop_response(self)
-	while true do
+	while self.__sock do
 		local func,co = table.remove(self.__request, 1), table.remove(self.__thread, 1)
 		if func then
 			return func, co


### PR DESCRIPTION
在`auth`认证失败时，会主动调用`close_channel_socket`,但是`pop_response`的携程并没有唤醒退出，导致内存泄漏。

修复前:
![QQ图片20240517111511](https://github.com/cloudwu/skynet/assets/41766775/c8922cf2-d830-40bd-8a92-4f640ee18f3b)
调试打印没有到`over`,也就是`dispatch_by_order`函数结束的地方。

![QQ图片20240517111746](https://github.com/cloudwu/skynet/assets/41766775/ba955cb7-7ef1-40bf-b8ef-c1cc9d2a9d7f)
弱引用表关联的channel对象会一直涨，说明没有释放(主动调用gc也不行)。

修复后:
![QQ图片20240517111532](https://github.com/cloudwu/skynet/assets/41766775/c736e254-cd7d-4392-93ed-cc0db50acca9)
`dispatch_by_order`函数执行完了。

![QQ图片20240517111700](https://github.com/cloudwu/skynet/assets/41766775/44e0ed8f-134a-4fbb-b00b-13074ed9ef05)
![QQ图片20240517111705](https://github.com/cloudwu/skynet/assets/41766775/9194acb2-8d60-4241-ba69-8abf84eef89d)


调用gc后，弱引用表对象减少了，说明释放了。

