### PR TITLE
修复打开DEBUG_LOG时，编译错误

### DIFF
--- a/service-src/service_snlua.c
+++ b/service-src/service_snlua.c
@@ -188,6 +188,7 @@ timing_resume(lua_State *L, int co_index, int n) {
 	if (timing_enable(L, co_index, &start_time)) {
 		start_time = get_time();
 #ifdef DEBUG_LOG
+		double ti = diff_time(start_time);
 		fprintf(stderr, "PROFILE [%p] resume %lf\n", co, ti);
 #endif
 		lua_pushvalue(L, co_index);


### PR DESCRIPTION
修复打开DEBUG_LOG宏时，会出现编译错误
![image](https://github.com/cloudwu/skynet/assets/5093114/6a24aea0-055c-4363-8b6d-3ad03e09e840)
