### PR TITLE
将工作线程数默认值修改为获取CPU核心数，减少运维需要根据不同配置的机器修改工作线程的数量 

### DIFF
--- a/skynet-src/skynet_main.c
+++ b/skynet-src/skynet_main.c
@@ -95,13 +95,13 @@ processor_num() {
 	mib[1] = HW_NCPU;
 	len = sizeof(processors);
 	if (sysctl(mib, 2, &processors, &len, NULL, 0) != -1 && processors >= 1) {
-		assert(len == sizeof(processors), "processors invalid");
+		assert(len == sizeof(processors));
 		return processors;
 	}
 	return 1;
 #else
 	int processors = sysconf(_SC_NPROCESSORS_ONLN);
-	assert(processors > 0, "processors invalid");
+	assert(processors > 0);
 	return processors;
 #endif
 }


### PR DESCRIPTION
将工作线程数默认值修改为获取CPU核心数，减少运维需要根据不同配置的机器修改工作线程的数量 