### PR TITLE
修复当环境变量是字符串时，替换后的代码没有加双引号，导致skynet无法正常启动

### DIFF
--- a/skynet-src/skynet_main.c
+++ b/skynet-src/skynet_main.c
@@ -102,7 +102,15 @@ static const char * load_config = "\
 		end\n\
 		local f = assert(io.open(current_path .. name))\n\
 		local code = assert(f:read [[*a]])\n\
-		code = string.gsub(code, [[%$([%w_%d]+)]], getenv)\n\
+		code = string.gsub(code, [[%$([%w_%d]+)]], function(s)\n\
+			local value = getenv(s)\n\
+			local n = tonumber(value)\n\
+			if n then\n\
+				return n\n\
+			end\n\
+			return string.format('\"%s\"', value)\n\
+		end)\n\
+		print(code)\n\
 		f:close()\n\
 		assert(load(code,[[@]]..filename,[[t]],result))()\n\
 		current_path = last_path\n\

--- a/skynet-src/skynet_main.c
+++ b/skynet-src/skynet_main.c
@@ -110,7 +110,6 @@ static const char * load_config = "\
 			end\n\
 			return string.format('\"%s\"', value)\n\
 		end)\n\
-		print(code)\n\
 		f:close()\n\
 		assert(load(code,[[@]]..filename,[[t]],result))()\n\
 		current_path = last_path\n\


### PR DESCRIPTION
修复前：
![image](https://github.com/cloudwu/skynet/assets/5093114/b6835c7f-5303-4838-b6cd-94da38841fc1)

![image](https://github.com/cloudwu/skynet/assets/5093114/fb4db42b-f1cb-4131-bdf0-1f48b0db9257)

修复后：
![image](https://github.com/cloudwu/skynet/assets/5093114/62c8cbba-cef3-4152-86da-dd5eafc43c0b)
