### PR TITLE
optimize timer bucket

### DIFF
--- a/skynet-src/skynet_timer.c
+++ b/skynet-src/skynet_timer.c
@@ -68,17 +68,17 @@ static void
 add_node(struct timer *T,struct timer_node *node) {
 	uint32_t time=node->expire;
 	uint32_t current_time=T->time;
-	
-	if ((time|TIME_NEAR_MASK)==(current_time|TIME_NEAR_MASK)) {
+	uint32_t diff = time - current_time;
+	diff >>= TIME_NEAR_SHIFT;
+	if (diff == 0) {
 		link(&T->near[time&TIME_NEAR_MASK],node);
 	} else {
 		int i;
-		uint32_t mask=TIME_NEAR << TIME_LEVEL_SHIFT;
 		for (i=0;i<3;i++) {
-			if ((time|(mask-1))==(current_time|(mask-1))) {
+			diff >>= TIME_LEVEL_SHIFT;
+			if (diff == 0) {
 				break;
 			}
-			mask <<= TIME_LEVEL_SHIFT;
 		}
 
 		link(&T->t[i][((time>>(TIME_NEAR_SHIFT + i*TIME_LEVEL_SHIFT)) & TIME_LEVEL_MASK)],node);	


### PR DESCRIPTION
这个PR优化了时间轮算法中`add_node`插入的位置，尽量插入低`level`的轮中。
考虑以下2个场景

1. 当前时间是0xFF，插入一个`expire`为0x100的定时器。原来的实现需要先插入到`level`0的`index`1的bucket，现在将直接插入到`near`的`index`0的bucket，下一个tick检查时会减少一次move操作。
2. 当前时间是0xFFFFFFFF，插入`expire`为0x0, 0x1, 0x2...的定时器，原来的实现都会放入`level`3的`index`0的bucket，下一个tick检查时需要大量move操作。现在将会更合理分散这些定时器的位置。