### PR TITLE
fix: 调整一个错误描述

### DIFF
--- a/lualib-src/lua-cluster.c
+++ b/lualib-src/lua-cluster.c
@@ -114,7 +114,7 @@ packreq_string(lua_State *L, int session, void * msg, uint32_t sz, int is_push) 
 		if (name == NULL) {
 			luaL_error(L, "name is not a string, it's a %s", lua_typename(L, lua_type(L, 1)));
 		} else {
-			luaL_error(L, "name is too long %s", name);
+			luaL_error(L, "name length is invalid, must be between 1 and 255 characters: %s", name);
 		}
 	}
 


### PR DESCRIPTION
调用`cluster.send(node, address, ...)`
当`address`是**空字符串**时，错误描述不准确："name is too long"
改成："name length is invalid, must be between 1 and 255 characters"