### PR TITLE
fix websocket accept mem leakage

### DIFF
--- a/lualib/http/websocket.lua
+++ b/lualib/http/websocket.lua
@@ -435,7 +435,7 @@ function M.accept(socket_id, handle, protocol, addr, options)
     ws_obj.addr = addr
     local on_warning = handle and handle["warning"]
     if on_warning then
-        socket.warning(socket_id, function (id, sz)
+        pcall(socket.warning, socket_id, function(id, sz)
             on_warning(ws_obj, sz)
         end)
     end

--- a/lualib/http/websocket.lua
+++ b/lualib/http/websocket.lua
@@ -428,16 +428,22 @@ end
 -- connect / handshake / message / ping / pong / close / error
 function M.accept(socket_id, handle, protocol, addr, options)
     if not (options and options.upgrade) then
-        socket.start(socket_id)
+        local isok, err = socket.start(socket_id)
+        if not isok then
+            return false, err
+        end
     end
     protocol = protocol or "ws"
     local ws_obj = _new_server_ws(socket_id, handle, protocol)
     ws_obj.addr = addr
     local on_warning = handle and handle["warning"]
     if on_warning then
-        pcall(socket.warning, socket_id, function(id, sz)
+        local isok = pcall(socket.warning, socket_id, function(id, sz)
             on_warning(ws_obj, sz)
         end)
+        if not isok then
+            return false, "connect is closed " .. socket_id
+        end
     end
 
     local ok, err = xpcall(resolve_accept, debug.traceback, ws_obj, options)

--- a/lualib/http/websocket.lua
+++ b/lualib/http/websocket.lua
@@ -442,6 +442,7 @@ function M.accept(socket_id, handle, protocol, addr, options)
             on_warning(ws_obj, sz)
         end)
         if not isok then
+            _close_websocket(ws_obj)
             return false, "connect is closed " .. socket_id
         end
     end

--- a/lualib/http/websocket.lua
+++ b/lualib/http/websocket.lua
@@ -442,7 +442,9 @@ function M.accept(socket_id, handle, protocol, addr, options)
             on_warning(ws_obj, sz)
         end)
         if not isok then
-            _close_websocket(ws_obj)
+            if not _isws_closed(socket_id) then
+                _close_websocket(ws_obj)
+            end
             return false, "connect is closed " .. socket_id
         end
     end


### PR DESCRIPTION
```txt
[:0000002e][20241206 15:22:36 74]lua call [0 to :2e : 0 msgsz = 38] error : [31m../../skynet_fly/skynet/lualib/skynet.lua:1031: ../../skynet_fly/skynet/lualib/skynet.lua:459: ../../skynet_fly/skynet/lualib/skynet\socket.lua:493: assertion failed!
stack traceback:
	[C]: in function 'assert'
	../../skynet_fly/skynet/lualib/skynet\socket.lua:493: in function 'skynet.socket.warning'
	../../skynet_fly/skynet/lualib/http\websocket.lua:438: in function 'http.websocket.accept'
	../../skynet_fly/service/ws_slave.lua:122: in local 'f'
	../../skynet_fly/lualib/skynet-fly\utils\skynet_util.lua:65: in upvalue 'f'
	../../skynet_fly/skynet/lualib/skynet.lua:409: in function <../../skynet_fly/skynet/lualib/skynet.lua:381>
stack traceback:
	[C]: in function 'assert'
	../../skynet_fly/skynet/lualib/skynet.lua:1031: in function 'skynet.dispatch_message'[0m
```