### PR TITLE
datacenterd query接口查询时,当db为nil时,终止递归

### DIFF
--- a/service/datacenterd.lua
+++ b/service/datacenterd.lua
@@ -6,7 +6,7 @@ local wait_queue = {}
 local mode = {}
 
 local function query(db, key, ...)
-	if key == nil then
+	if db == nil or key == nil then
 		return db
 	else
 		return query(db[key], ...)


### PR DESCRIPTION
datacenterd query接口查询时,当db为nil时,终止递归