### PR TITLE
fix socketchannel closed thread not wakeup

### DIFF
--- a/lualib/skynet/socketchannel.lua
+++ b/lualib/skynet/socketchannel.lua
@@ -116,6 +116,11 @@ local function dispatch_by_session(self)
 					end
 					skynet.wakeup(co)
 				end
+				if not self.__sock then
+					-- closed
+					wakeup_all(self, "channel_closed")
+					break
+				end
 			else
 				self.__thread[session] = nil
 				skynet.error("socket: unknown session :", session)
@@ -211,6 +216,11 @@ local function dispatch_by_order(self)
 				self.__result_data[co] = result_data
 			end
 			skynet.wakeup(co)
+			if not self.__sock then
+				-- closed
+				wakeup_all(self, "channel_closed")
+				break
+			end
 		else
 			close_channel_socket(self)
 			local errmsg


### PR DESCRIPTION
##`dispatch_by_session` 修复后测试结果
```txt
[:0000000f][20241230 17:30:10 01]connect from 127.0.0.1:60548
[:0000000f][20241230 17:30:10 01]recv: session = 1 data = hello world 1
[:0000000f][20241230 17:30:10 02]recv: session = 2 data = hello world 2
[:0000000f][20241230 17:30:10 03]recv: session = 3 data = hello world 3
[:0000000f][20241230 17:30:10 04]recv: session = 4 data = hello world 4
[:0000000f][20241230 17:30:10 05]recv: session = 5 data = hello world 5
[:0000000f][20241230 17:30:10 06]recv: session = 6 data = hello world 6
[:0000000f][20241230 17:30:10 07]recv: session = 7 data = hello world 7
[:0000000f][20241230 17:30:10 08]recv: session = 8 data = hello world 8
[:0000000f][20241230 17:30:10 09]recv: session = 9 data = hello world 9
[:0000000f][20241230 17:30:10 10]recv: session = 10 data = hello world 10
[:0000000e][20241230 17:30:10 11]close begin
[:0000000e][20241230 17:30:10 11]>>>  1 hello world 1
[:0000000e][20241230 17:30:10 11]rsp :  1 true hello world 1
[:0000000e][20241230 17:30:10 11]rsp :  2 false ../skynet/lualib/skynet/socketchannel.lua:487: channel_closed
[:0000000e][20241230 17:30:10 11]rsp :  3 false ../skynet/lualib/skynet/socketchannel.lua:487: channel_closed
[:0000000e][20241230 17:30:10 11]rsp :  4 false ../skynet/lualib/skynet/socketchannel.lua:487: channel_closed
[:0000000e][20241230 17:30:10 11]rsp :  5 false ../skynet/lualib/skynet/socketchannel.lua:487: channel_closed
[:0000000e][20241230 17:30:10 11]rsp :  6 false ../skynet/lualib/skynet/socketchannel.lua:487: channel_closed
[:0000000e][20241230 17:30:10 11]rsp :  7 false ../skynet/lualib/skynet/socketchannel.lua:487: channel_closed
[:0000000e][20241230 17:30:10 11]rsp :  8 false ../skynet/lualib/skynet/socketchannel.lua:487: channel_closed
[:0000000e][20241230 17:30:10 11]rsp :  9 false ../skynet/lualib/skynet/socketchannel.lua:487: channel_closed
[:0000000e][20241230 17:30:10 11]rsp :  10 false ../skynet/lualib/skynet/socketchannel.lua:487: channel_closed
[:0000000f][20241230 17:30:10 11]socket: error on 4 Connection reset by peer
[:0000000f][20241230 17:30:10 11]disconnect from 127.0.0.1:60548
[:0000000e][20241230 17:30:10 11]close end
[:0000000e][20241230 17:30:11 11][info][socket_channel_m][./module/socket_channel_m.lua:80]{
        ["__request"] =  {
        }
        ["__connecting"] =  {
        }
        ["__response"] = function: 0x7f6f7125de20,
        ["__authcoroutine"] = false,
        ["__thread"] =  {
        }
        ["__closed"] = true,
        ["__sock"] = false,
```

### `dispatch_by_order` 修复后测试结果
```lua
[:0000000f][20241230 17:37:01 16]socket listen on  10001
[:0000000f][20241230 17:37:01 16]connect from 127.0.0.1:40592
[:0000000f][20241230 17:37:01 16]recv: data = hello world 1
[:0000000f][20241230 17:37:01 17]recv: data = hello world 2
[:0000000f][20241230 17:37:01 18]recv: data = hello world 3
[:0000000f][20241230 17:37:01 19]recv: data = hello world 4
[:0000000f][20241230 17:37:01 20]recv: data = hello world 5
[:0000000f][20241230 17:37:01 21]recv: data = hello world 6
[:0000000f][20241230 17:37:01 22]recv: data = hello world 7
[:0000000f][20241230 17:37:01 23]recv: data = hello world 8
[:0000000f][20241230 17:37:01 24]recv: data = hello world 9
[:0000000f][20241230 17:37:01 25]recv: data = hello world 10
[:0000000e][20241230 17:37:01 26]close begin
[:0000000e][20241230 17:37:01 26]>>>  hello world 1
[:0000000e][20241230 17:37:01 26]dispatch_by_order >>>  true true hello world 1 false
[:0000000e][20241230 17:37:01 26]rsp :  1 true hello world 1
[:0000000e][20241230 17:37:01 26]rsp :  2 false ../skynet/lualib/skynet/socketchannel.lua:492: channel_closed
[:0000000e][20241230 17:37:01 26]rsp :  3 false ../skynet/lualib/skynet/socketchannel.lua:492: channel_closed
[:0000000e][20241230 17:37:01 26]rsp :  4 false ../skynet/lualib/skynet/socketchannel.lua:492: channel_closed
[:0000000e][20241230 17:37:01 26]rsp :  5 false ../skynet/lualib/skynet/socketchannel.lua:492: channel_closed
[:0000000e][20241230 17:37:01 26]rsp :  6 false ../skynet/lualib/skynet/socketchannel.lua:492: channel_closed
[:0000000e][20241230 17:37:01 26]rsp :  7 false ../skynet/lualib/skynet/socketchannel.lua:492: channel_closed
[:0000000e][20241230 17:37:01 26]rsp :  8 false ../skynet/lualib/skynet/socketchannel.lua:492: channel_closed
[:0000000e][20241230 17:37:01 26]rsp :  9 false ../skynet/lualib/skynet/socketchannel.lua:492: channel_closed
[:0000000e][20241230 17:37:01 26]rsp :  10 false ../skynet/lualib/skynet/socketchannel.lua:492: channel_closed
[:0000000f][20241230 17:37:01 26]socket: error on 4 Connection reset by peer
[:0000000f][20241230 17:37:01 26]disconnect from 127.0.0.1:40592
[:0000000e][20241230 17:37:01 26]close end
[:0000000e][20241230 17:37:02 26][info][socket_channel_m][./module/socket_channel_m.lua:161]{
        ["__request"] =  {
        }
        ["__result_data"] =  {
        }
        ["__sock"] = false,
```
