### PR TITLE
在macosx上开启jemalloc和malloc_hook

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -33,8 +33,8 @@ linux freebsd : SKYNET_LIBS += -lrt
 
 # Turn off jemalloc and malloc hook on macosx
 
-macosx : MALLOC_STATICLIB :=
-macosx : SKYNET_DEFINES :=-DNOUSE_JEMALLOC
+#macosx : MALLOC_STATICLIB :=
+#macosx : SKYNET_DEFINES :=-DNOUSE_JEMALLOC
 
 linux macosx freebsd :
 	$(MAKE) all PLAT=$@ SKYNET_LIBS="$(SKYNET_LIBS)" SHARED="$(SHARED)" EXPORT="$(EXPORT)" MALLOC_STATICLIB="$(MALLOC_STATICLIB)" SKYNET_DEFINES="$(SKYNET_DEFINES)"

--- a/skynet-src/malloc_hook.c
+++ b/skynet-src/malloc_hook.c
@@ -238,10 +238,18 @@ alignment_cookie_size(size_t alignment) {
 
 void *
 skynet_memalign(size_t alignment, size_t size) {
+#ifdef __APPLE__
+	void* ptr;
+	uint32_t cookie_size = alignment_cookie_size(alignment);
+	int ret = je_posix_memalign(&ptr, alignment, size + cookie_size);
+	if(ret) malloc_oom(size);
+	return fill_prefix(ptr, size, cookie_size);
+#else
 	uint32_t cookie_size = alignment_cookie_size(alignment);
 	void* ptr = je_memalign(alignment, size + cookie_size);
 	if(!ptr) malloc_oom(size);
 	return fill_prefix(ptr, size, cookie_size);
+#endif
 }
 
 void *


### PR DESCRIPTION
之前编译不过的原因，是 mac 系统上，没有 memalign 函数。如果 jemalloc 的 autoconf 检测不到 memalign 函数，则它不会暴露 je_memalign 符号。

这个 PR，尝试在 macos 系统上，使用 posix_memalign 来实现 skynet_memalign，使其能编译通过。

是我本地开发机是 mac，需要使用到 malloc_hook，期望能支持一下。