### PR TITLE
* 增加mysql使用execute方法解析date格式数据

### DIFF
--- a/lualib/skynet/db/mysql.lua
+++ b/lualib/skynet/db/mysql.lua
@@ -852,6 +852,21 @@ local function _get_datetime(data, pos)
     return value, pos
 end
 
+local function _get_date(data, pos)
+    local len, year, month, day
+    local value
+    len, pos = _from_length_coded_bin(data, pos)
+    if len == 4 then
+        year, month, day, pos = string.unpack("<I2BB", data, pos)
+        value = strformat("%04d-%02d-%02d", year, month, day)
+    else
+        value = "1970-01-01"
+        --unsupported format
+        pos = pos + len
+    end
+    return value, pos
+end
+
 -- 字段类型参考 https://dev.mysql.com/doc/dev/mysql-server/8.0.12/binary__log__types_8h.html enum_field_types 枚举类型定义
 local _binary_parser = {
     [0x01] = _get_int1,
@@ -862,6 +877,7 @@ local _binary_parser = {
     [0x07] = _get_datetime,
     [0x08] = _get_int8,
     [0x09] = _get_int3,
+    [0x0a] = _get_date,
     [0x0c] = _get_datetime,
     [0x0f] = _from_length_coded_str,
     [0x10] = _from_length_coded_str,

--- a/lualib/skynet/db/mysql.lua
+++ b/lualib/skynet/db/mysql.lua
@@ -860,9 +860,8 @@ local function _get_date(data, pos)
         year, month, day, pos = string.unpack("<I2BB", data, pos)
         value = strformat("%04d-%02d-%02d", year, month, day)
     else
-        value = "1970-01-01"
         --unsupported format
-        pos = pos + len
+        error("_get_date()error,unsupported date format, len is " .. len)
     end
     return value, pos
 end


### PR DESCRIPTION

#2034 

修复了通过如下方法解析date类型数据的问题

```lua
-- day在MySQL中是date类型
local sql = "select day from tab where day = ? "
local stmt_sql = db:prepare(sql)
local res = db:execute(stmt_sql, "2020-01-01")
```