### PR TITLE
allow `t[nil] => nil` in table returned by sharedata

### DIFF
--- a/lualib-src/lua-sharedata.c
+++ b/lualib-src/lua-sharedata.c
@@ -540,7 +540,9 @@ lindexconf(lua_State *L) {
 	int keytype;
 	size_t sz = 0;
 	const char * str = NULL;
-	if (kt == LUA_TNUMBER) {
+	if (kt == LUA_TNIL) {
+		return 0;
+	} else if (kt == LUA_TNUMBER) {
 		if (!lua_isinteger(L, 2)) {
 			return luaL_error(L, "Invalid key %f", lua_tonumber(L, 2));
 		}


### PR DESCRIPTION
resolves #2036 

允許對 sharedata 返回的 table 做讀取 `t[nil]`
會返回 `nil` 而不是報錯
詳細討論見該 issue