### PR TITLE
fixed: service_gate_c  half close

### DIFF
--- a/service-src/service_gate.c
+++ b/service-src/service_gate.c
@@ -250,6 +250,7 @@ dispatch_socket_message(struct gate *g, const struct skynet_socket_message * mes
 			memset(c, 0, sizeof(*c));
 			c->id = -1;
 			_report(g, "%d close", message->id);
+			skynet_socket_close(ctx, message->id);
 		}
 		break;
 	}


### PR DESCRIPTION
当前端主动关闭socket时，应用层无法正确的 kick fd  `int id = hashid_remove(&g->hash, message->id);`  产生 CLOSE-WAIT