### PR TITLE
build: 优化 Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.a
+*.d
 /skynet
 /skynet.pid
 3rd/lua/lua

--- a/skynet-src/skynet_error.c
+++ b/skynet-src/skynet_error.c
@@ -8,9 +8,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#define LOG_MESSAGE_SIZE 256
-
-void 
+void
 skynet_error(struct skynet_context * context, const char *msg, ...) {
 	static uint32_t logger = 0;
 	if (logger == 0) {
@@ -20,36 +18,15 @@ skynet_error(struct skynet_context * context, const char *msg, ...) {
 		return;
 	}
 
-	char tmp[LOG_MESSAGE_SIZE];
 	char *data = NULL;
-
 	va_list ap;
-
 	va_start(ap,msg);
-	int len = vsnprintf(tmp, LOG_MESSAGE_SIZE, msg, ap);
+	int len = skynet_vasprintf(&data, msg, ap);
 	va_end(ap);
-	if (len >=0 && len < LOG_MESSAGE_SIZE) {
-		data = skynet_strdup(tmp);
-	} else {
-		int max_size = LOG_MESSAGE_SIZE;
-		for (;;) {
-			max_size *= 2;
-			data = skynet_malloc(max_size);
-			va_start(ap,msg);
-			len = vsnprintf(data, max_size, msg, ap);
-			va_end(ap);
-			if (len < max_size) {
-				break;
-			}
-			skynet_free(data);
-		}
-	}
 	if (len < 0) {
-		skynet_free(data);
-		perror("vsnprintf error :");
+		perror("vasprintf error :");
 		return;
 	}
-
 
 	struct skynet_message smsg;
 	if (context == NULL) {
@@ -62,4 +39,3 @@ skynet_error(struct skynet_context * context, const char *msg, ...) {
 	smsg.sz = len | ((size_t)PTYPE_TEXT << MESSAGE_TYPE_SHIFT);
 	skynet_context_push(logger, &smsg);
 }
-

--- a/skynet-src/skynet_malloc.h
+++ b/skynet-src/skynet_malloc.h
@@ -11,11 +11,15 @@
 #define skynet_aligned_alloc aligned_alloc
 #define skynet_posix_memalign posix_memalign
 
+#define skynet_asprintf asprintf
+#define skynet_vasprintf vasprintf
+#define skynet_strdup strdup
+#define skynet_strndup strndup
+
 void * skynet_malloc(size_t sz);
 void * skynet_calloc(size_t nmemb,size_t size);
 void * skynet_realloc(void *ptr, size_t size);
 void skynet_free(void *ptr);
-char * skynet_strdup(const char *str);
 void * skynet_lalloc(void *ptr, size_t osize, size_t nsize);	// use for lua
 void * skynet_memalign(size_t alignment, size_t size);
 void * skynet_aligned_alloc(size_t alignment, size_t size);


### PR DESCRIPTION
1. Makefile: 采用独立 .o 编译流程，避免全量重建
2. Makefile: 增加头文件依赖追踪
3. Makefile: 支持检测系统非标准扩展
4. skynet_error.c: 使用 vasprintf 简化错误消息处理
5. malloc_hook.c: 优化 strdup/vasprintf 实现策略
6. socket_server.c: 修复结构体初始化 valgrind 警告