### PR TITLE
skynet.socket需要解析域名的接口,先通过dns.resolve解析,避免传递到网络线程中调用getaddrinfo导致线程阻塞,影响网络收发

### DIFF
--- a/test/testsocket_dns.lua
+++ b/test/testsocket_dns.lua
@@ -1,0 +1,89 @@
+local skynet = require "skynet"
+local socket = require "skynet.socket"
+local driver = require "skynet.socketdriver"
+local dns = require "skynet.dns"
+
+local function test_socket_open_with_dns()
+	-- Test DNS resolution
+	local id = socket.open("www.baidu.com", 80)
+	assert(id, "Failed to connect to www.baidu.com")
+	socket.close(id)
+
+	-- Test IP connection
+	id = socket.open("8.8.8.8", 53)
+	assert(id, "Failed to connect to 8.8.8.8")
+	socket.close(id)
+end
+
+local function test_invalid_domain()
+	-- Should fail for invalid domain
+	local status, result = pcall(socket.open, "nonexistent.invalid.domain", 80)
+	assert(not (status and result), "Should not connect to invalid domain")
+end
+
+local function test_concurrent_dns_resolution()
+	local domains = {"www.github.com", "www.google.com", "www.baidu.com"}
+	local results = {}
+
+	for i, domain in ipairs(domains) do
+		skynet.fork(function()
+			local id = socket.open(domain, 80)
+			results[i] = id ~= nil
+			if id then socket.close(id) end
+		end)
+	end
+
+	skynet.sleep(300) -- Wait for completion
+
+	-- Verify most connections succeeded (async DNS should work)
+	local success_count = 0
+	for _, success in ipairs(results) do
+		if success then success_count = success_count + 1 end
+	end
+	assert(success_count >= 2, "Too many concurrent DNS failures")
+end
+
+local function test_udp_dns_resolution()
+	local response_received = false
+	local id = socket.udp(function(str, from)
+		response_received = #str >= 12 -- Valid DNS response
+	end)
+
+	socket.udp_connect(id, "dns.google", 53)
+
+	-- Simple DNS query for google.com
+	local dns_query = string.char(0xaa, 0xbb, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00) ..
+		"\x06google\x03com\x00" .. string.char(0x00, 0x01, 0x00, 0x01)
+
+	socket.write(id, dns_query)
+
+	-- Wait for response
+	for i = 1, 20 do
+		if response_received then break end
+		skynet.sleep(10)
+	end
+
+	socket.close(id)
+	assert(response_received, "UDP DNS query failed")
+end
+
+local function main()
+	dns.server("8.8.8.8", 53)
+
+	print("Testing basic DNS resolution...")
+	test_socket_open_with_dns()
+
+	print("Testing invalid domain handling...")
+	test_invalid_domain()
+
+	print("Testing concurrent DNS resolution...")
+	test_concurrent_dns_resolution()
+
+	print("Testing UDP DNS resolution...")
+	test_udp_dns_resolution()
+
+	print("All DNS tests passed!")
+	skynet.exit()
+end
+
+skynet.start(main)


### PR DESCRIPTION
# 背景
    现在项目中有不少地方通过skynet/socket.lua来创建连接,比如http, mongo连接, etcd, redis等. 在阿里云这些系统上,大部分都是通过配置域名的方式来做高可用。经常会遇到dns网络故障或者负载问题，导致解析没返回。 而现在的socket.lua又需要在socket_server中执行getaddrinfo这个阻塞线程的操作来解析域名,因此时不时会遇到因为dns问题,引起多个业务的网络io卡住的问题.
    之前的方案主要是通过发现一个模块直接用socket.open创建的地方,修改为dns.resolve后再open的方式,实践下来在不同的项目中总是有疏漏. 因此期望能够在skynet/socket层去掉getaddrinfo.
# 改动点
   1. socket.lua中添加dns.resolve解析, socket_server直接处理ip地址,就不会再卡住.
   2. dns.lua中添加 nameserver的检查,避免nameserver配置了域名的形式 (标准要求)
