### PR TITLE
fix #2121 : use same hash seed when creating VM for shared tables

### DIFF
--- a/lualib-src/lua-sharetable.c
+++ b/lualib-src/lua-sharetable.c
@@ -192,7 +192,7 @@ load_matrixfile(lua_State *L) {
 
 static int
 matrix_from_file(lua_State *L) {
-	lua_State *mL = luaL_newstate();
+	lua_State *mL = lua_newstate(luaL_alloc, NULL, G(L)->seed);
 	if (mL == NULL) {
 		return luaL_error(L, "luaL_newstate failed");
 	}


### PR DESCRIPTION
When creating a new Lua VM to load shared tables, use the same hash seed from the parent VM instead of generating a new random seed.

Different VMs have different hash seeds, causing identical strings to have different hash values. When looking up string keys in a shared table from another VM, the hash-based bucket lookup fails because the search key's hash doesn't match the stored key's hash.

Solution: Pass G(L)->seed to lua_newstate() instead of using luaL_newstate() which generates a new random seed each time.