### PR TITLE
fix: 修复升级lua5.5后的兼容性错误

### DIFF
--- a/lualib/skynet.lua
+++ b/lualib/skynet.lua
@@ -992,19 +992,19 @@ function skynet.newservice(name, ...)
 	return skynet.call(".launcher", "lua" , "LAUNCH", "snlua", name, ...)
 end
 
-function skynet.uniqueservice(global, ...)
-	if global == true then
+function skynet.uniqueservice(name, ...)
+	if name == true then
 		return assert(skynet.call(".service", "lua", "GLAUNCH", ...))
 	else
-		return assert(skynet.call(".service", "lua", "LAUNCH", global, ...))
+		return assert(skynet.call(".service", "lua", "LAUNCH", name, ...))
 	end
 end
 
-function skynet.queryservice(global, ...)
-	if global == true then
+function skynet.queryservice(name, ...)
+	if name == true then
 		return assert(skynet.call(".service", "lua", "GQUERY", ...))
 	else
-		return assert(skynet.call(".service", "lua", "QUERY", global, ...))
+		return assert(skynet.call(".service", "lua", "QUERY", name, ...))
 	end
 end
 

--- a/lualib/skynet/db/redis.lua
+++ b/lualib/skynet/db/redis.lua
@@ -213,10 +213,11 @@ end
 local function compose_table(lines, msg)
 	local tinsert = table.insert
 	tinsert(lines, count_cache[#msg])
+	local val
 	for _,v in ipairs(msg) do
-		v = tostring(v)
-		tinsert(lines,header_cache[#v])
-		tinsert(lines,v)
+		val = tostring(v)
+		tinsert(lines,header_cache[#val])
+		tinsert(lines,val)
 	end
 	tinsert(lines, "\r\n")
 	return lines

--- a/lualib/skynet/dns.lua
+++ b/lualib/skynet/dns.lua
@@ -130,11 +130,11 @@ local function parse_hosts()
 		end
 
 		for host in hosts:gmatch("%S+") do
-			host = host:lower()
-			local rt = rts[host]
+			local h = host:lower()
+			local rt = rts[h]
 			if not rt then
 				rt = {}
-				rts[host] = rt
+				rts[h] = rt
 			end
 
 			if not rt[family] then

--- a/service/clusterd.lua
+++ b/service/clusterd.lua
@@ -102,9 +102,9 @@ local function loadconfig(tmp)
 	local reload = {}
 	for name,address in pairs(tmp) do
 		if name:sub(1,2) == "__" then
-			name = name:sub(3)
-			config[name] = address
-			skynet.error(string.format("Config %s = %s", name, address))
+			local opt = name:sub(3)
+			config[opt] = address
+			skynet.error(string.format("Config %s = %s", opt, address))
 		else
 			assert(address == false or type(address) == "string")
 			if node_address[name] ~= address then

--- a/service/service_mgr.lua
+++ b/service/service_mgr.lua
@@ -96,10 +96,11 @@ function cmd.QUERY(service_name, subname)
 end
 
 local function list_service()
+	local val
 	local result = {}
 	for k,v in pairs(service) do
 		if type(v) == "string" then
-			v = "Error: " .. v
+			val = "Error: " .. v
 		elseif type(v) == "table" then
 			local querying = {}
 			if v.launch then
@@ -118,12 +119,12 @@ local function list_service()
 					table.insert(querying, skynet.address(detail.source) .. " " .. tostring(skynet.call(detail.source, "debug", "TASK", detail.session)))
 				end
 			end
-			v = table.concat(querying, "\n")
+			val = table.concat(querying, "\n")
 		else
-			v = skynet.address(v)
+			val = skynet.address(v)
 		end
 
-		result[k] = v
+		result[k] = val
 	end
 
 	return result


### PR DESCRIPTION
更新到lua5.5 后，出现一些兼容性报错：
- global 关键字占用
- for loop 中对常量进行赋值报错（attempt to assign to const variable ）