### PR TITLE
skynet移植到OpenBSD

### DIFF
--- a/3rd/lua/makefile
+++ b/3rd/lua/makefile
@@ -30,7 +30,7 @@ CMCFLAGS=
 
 # == END OF USER SETTINGS -- NO NEED TO CHANGE ANYTHING BELOW THIS LINE =======
 
-PLATS= guess aix bsd c89 freebsd generic ios linux macosx mingw posix solaris
+PLATS= guess aix bsd c89 freebsd generic ios linux macosx mingw posix solaris openbsd
 
 LUA_A=	liblua.a
 CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o
@@ -112,7 +112,7 @@ c89:
 	@echo '*** with LUA_USE_C89 to ensure consistency'
 	@echo ''
 
-FreeBSD NetBSD OpenBSD freebsd:
+FreeBSD NetBSD OpenBSD freebsd openbsd:
 	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX -DLUA_USE_READLINE -I/usr/include/edit" SYSLIBS="-Wl,-E -ledit" CC="cc"
 
 generic: $(ALL)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For Linux, install autoconf first for jemalloc:
 ```
 git clone https://github.com/cloudwu/skynet.git
 cd skynet
-make 'PLATFORM'  # PLATFORM can be linux, macosx, freebsd now
+make 'PLATFORM'  # PLATFORM can be linux, macosx, freebsd, openbsd now
 ```
 
 Or:

--- a/platform.mk
+++ b/platform.mk
@@ -1,5 +1,5 @@
 PLAT ?= none
-PLATS = linux freebsd macosx mingw
+PLATS = linux freebsd openbsd macosx mingw
 
 CC ?= gcc
 
@@ -25,6 +25,7 @@ EXPORT := -Wl,-E
 linux : PLAT = linux
 macosx : PLAT = macosx
 freebsd : PLAT = freebsd
+openbsd : PLAT = openbsd
 mingw : PLAT = mingw
 
 macosx : SHARED := -fPIC -dynamiclib -Wl,-undefined,dynamic_lookup
@@ -34,10 +35,10 @@ linux freebsd : SKYNET_LIBS += -lrt
 
 # Turn off jemalloc and malloc hook on macosx
 
-macosx : MALLOC_STATICLIB :=
-macosx : SKYNET_DEFINES :=-DNOUSE_JEMALLOC
+openbsd macosx : MALLOC_STATICLIB :=
+openbsd macosx : SKYNET_DEFINES :=-DNOUSE_JEMALLOC
 
-linux macosx freebsd :
+linux macosx freebsd openbsd :
 	$(MAKE) all PLAT=$@ SKYNET_LIBS="$(SKYNET_LIBS)" SHARED="$(SHARED)" EXPORT="$(EXPORT)" MALLOC_STATICLIB="$(MALLOC_STATICLIB)" SKYNET_DEFINES="$(SKYNET_DEFINES)"
 
 mingw :

--- a/skynet-src/socket_server.c
+++ b/skynet-src/socket_server.c
@@ -6,6 +6,7 @@
 #include "spinlock.h"
 
 #include <sys/types.h>
+#include <sys/select.h>
 #include <sys/socket.h>
 #include <netinet/tcp.h>
 #include <unistd.h>


### PR DESCRIPTION
修改 Makefile 支持 OpenBSD 系统。

**关于屏蔽 jemalloc**

OpenBSD libc malloc 比较特殊，自带很多安全措施。为符合 OpenBSD 哲学，jemalloc 不开启。

```
On OpenBSD using jemalloc by default would be considered an exploit
mitigation countermeasure. jemalloc may have better performance, but
different operating systems have different priorities, and certainly on
OpenBSD we would want to use the system malloc to benefit from security
features like guard pages, canaries, free checking, and free unmapping.
```

参考：https://redmine.ruby-lang.org/issues/14718

**关于 include sys/select.h**

根据 POSIX.1-2017 标准，fd_set 定义在 sys/select.h 中。否则 OpenBSD 上编译，找不到 fd_set。
