### PR TITLE
为 sharetable 增加保留引用的全 worker 原子 merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,8 @@ LUA_CLIB_SKYNET = \
 SKYNET_SRC = skynet_main.c skynet_handle.c skynet_module.c skynet_mq.c \
   skynet_server.c skynet_start.c skynet_timer.c skynet_error.c \
   skynet_harbor.c skynet_env.c skynet_monitor.c skynet_socket.c socket_server.c \
-  mem_info.c malloc_hook.c skynet_daemon.c skynet_log.c
+  mem_info.c malloc_hook.c skynet_daemon.c skynet_log.c \
+  skynet_worker_control.c
 
 all : \
   $(SKYNET_BUILD_PATH)/skynet \

--- a/lualib-src/lua-sharetable.c
+++ b/lualib-src/lua-sharetable.c
@@ -3,8 +3,18 @@
 #include <lua.h>
 #include <lauxlib.h>
 #include <lualib.h>
+#include <math.h>
+#include <string.h>
 
+#include "lapi.h"
 #include "lgc.h"
+#include "lobject.h"
+#include "lstate.h"
+#include "ltable.h"
+
+#include "lua-seri.h"
+#include "skynet_malloc.h"
+#include "skynet_worker_control.h"
 
 #ifdef makeshared
 
@@ -35,15 +45,6 @@ mark_shared(lua_State *L) {
 			case LUA_TBOOLEAN:
 			case LUA_TLIGHTUSERDATA:
 				break;
-			case LUA_TFUNCTION:
-				if (lua_getupvalue(L, idx, 1) != NULL) {
-					luaL_error(L, "Invalid function with upvalue");
-				} else if (!lua_iscfunction(L, idx)) {
-					LClosure *f = (LClosure *)lua_topointer(L, idx);
-					makeshared(f);
-					lua_sharefunction(L, idx);
-				}
-				break;
 			case LUA_TSTRING:
 				lua_sharestring(L, idx);
 				break;
@@ -68,55 +69,22 @@ lis_sharedtable(lua_State* L) {
 }
 
 static int
-make_matrix(lua_State *L) {
-	// turn off gc , because marking shared will prevent gc mark.
-	lua_gc(L, LUA_GCSTOP, 0);
-	mark_shared(L);
-	Table * t = (Table *)lua_topointer(L, -1);
-	lua_pushlightuserdata(L, t);
-	return 1;
-}
-
-static int
 clone_table(lua_State *L) {
 	lua_clonetable(L, lua_touserdata(L, 1));
 
 	return 1;
 }
 
-static int
-lco_stackvalues(lua_State* L) {
-    lua_State *cL = lua_tothread(L, 1);
-    luaL_argcheck(L, cL, 1, "thread expected");
-    int n = 0;
-    if(cL != L) {
-        luaL_checktype(L, 2, LUA_TTABLE);
-        n = lua_gettop(cL);
-        if(n > 0) {
-            luaL_checkstack(L, n+1, NULL);
-            int top = lua_gettop(L);
-            lua_xmove(cL, L, n);
-            int i=0;
-            for(i=1; i<=n; i++) {
-                lua_pushvalue(L, top+i);
-                lua_seti(L, 2, i);
-            }
-            lua_xmove(L, cL, n);
-        }
-    }
-
-    lua_pushinteger(L, n);
-    return 1;
-}
-
-
 struct state_ud {
 	lua_State *L;
+	unsigned int lease;
 };
 
 static int
 close_state(lua_State *L) {
 	struct state_ud *ud = (struct state_ud *)luaL_checkudata(L, 1, "BOXMATRIXSTATE");
+	if (ud->lease != 0)
+		return luaL_error(L, "matrix update is in progress");
 	if (ud->L) {
 		lua_close(ud->L);
 		ud->L = NULL;
@@ -149,11 +117,390 @@ get_size(lua_State *L) {
 	return 1;
 }
 
+struct merge_plan {
+	struct state_ud **matrices;
+	size_t matrix_count;
+	size_t matrix_capacity;
+	struct skynet_sharetable_storage_swap *swaps;
+	size_t swap_count;
+	size_t swap_capacity;
+};
+
+struct merge_job {
+	struct merge_plan *plan;
+	Table *stable;
+	const void **seen_tables;
+	size_t seen_count;
+	size_t seen_capacity;
+	int seen_index;  // 0 when candidate transport already guarantees a tree
+	const char *error;
+};
+
+static int
+merge_fail(struct merge_job *job, const char *error) {
+	job->error = error;
+	return 0;
+}
+
+static int
+remember_table(lua_State *L, struct merge_job *job, const void *table) {
+	if (job->seen_index != 0) {
+		lua_pushlightuserdata(L, (void *)table);
+		lua_rawget(L, job->seen_index);
+		if (!lua_isnil(L, -1)) {
+			lua_pop(L, 1);
+			return 0;
+		}
+		lua_pop(L, 1);
+		lua_pushlightuserdata(L, (void *)table);
+		lua_pushboolean(L, 1);
+		lua_rawset(L, job->seen_index);
+		return 1;
+	}
+	if (job->seen_count == job->seen_capacity) {
+		size_t capacity = job->seen_capacity == 0 ? 64 :
+			job->seen_capacity * 2;
+		const void **tables = skynet_realloc(job->seen_tables,
+			capacity * sizeof(*tables));
+		job->seen_tables = tables;
+		job->seen_capacity = capacity;
+	}
+	job->seen_tables[job->seen_count++] = table;
+	return 1;
+}
+
+static int
+validate_scalar(lua_State *L, int index, struct merge_job *job, int key) {
+	switch (lua_type(L, index)) {
+	case LUA_TBOOLEAN:
+	case LUA_TSTRING:
+	case LUA_TLIGHTUSERDATA:
+		return 1;
+	case LUA_TNUMBER:
+		if (!lua_isinteger(L, index) &&
+			!isfinite((double)lua_tonumber(L, index)))
+			return merge_fail(job, "ShareTable numbers must be finite");
+		return 1;
+	default:
+		return merge_fail(job, key ? "invalid ShareTable key" :
+			"invalid ShareTable value");
+	}
+}
+
+static int
+validate_table(lua_State *L, int index, struct merge_job *job) {
+	index = lua_absindex(L, index);
+	if (!lua_checkstack(L, 4))
+		return merge_fail(job, "ShareTable tree is too deep");
+	if (lua_getmetatable(L, index)) {
+		lua_pop(L, 1);
+		return merge_fail(job, "ShareTable tables cannot have metatables");
+	}
+	Table *table = (Table *)lua_topointer(L, index);
+	if (isshared(table))
+		return merge_fail(job, "ShareTable source must build a fresh table tree");
+	int seen = remember_table(L, job, table);
+	if (seen == 0)
+		return merge_fail(job, "ShareTable cannot contain aliases or cycles");
+
+	lua_pushnil(L);
+	while (lua_next(L, index) != 0) {
+		if (!validate_scalar(L, -2, job, 1)) {
+			lua_pop(L, 2);
+			return 0;
+		}
+		if (lua_type(L, -1) == LUA_TTABLE) {
+			if (!validate_table(L, -1, job)) {
+				lua_pop(L, 2);
+				return 0;
+			}
+		} else if (!validate_scalar(L, -1, job, 0)) {
+			lua_pop(L, 2);
+			return 0;
+		}
+		lua_pop(L, 1);
+	}
+	return 1;
+}
+
+static int
+make_matrix(lua_State *L) {
+	lua_newtable(L);
+	struct merge_job job;
+	memset(&job, 0, sizeof(job));
+	job.seen_index = lua_absindex(L, -1);
+	if (!validate_table(L, -2, &job))
+		return luaL_error(L, "%s", job.error);
+	lua_pop(L, 1);
+	lua_gc(L, LUA_GCCOLLECT, 0);
+	// turn off gc , because marking shared will prevent gc mark.
+	lua_gc(L, LUA_GCSTOP, 0);
+	G(L)->gcstopem = 1;
+	mark_shared(L);
+	Table * t = (Table *)lua_topointer(L, -1);
+	lua_pushlightuserdata(L, t);
+	return 1;
+}
+
+static void
+plan_add_swap(struct merge_job *job, Table *stable, Table *staging) {
+	struct merge_plan *plan = job->plan;
+	if (plan->swap_count == plan->swap_capacity) {
+		size_t capacity = plan->swap_capacity == 0 ? 64 :
+			plan->swap_capacity * 2;
+		struct skynet_sharetable_storage_swap *swaps = skynet_realloc(
+			plan->swaps, capacity * sizeof(*swaps));
+		plan->swaps = swaps;
+		plan->swap_capacity = capacity;
+	}
+	plan->swaps[plan->swap_count].stable = stable;
+	plan->swaps[plan->swap_count].staging = staging;
+	plan->swap_count++;
+}
+
+static void
+plan_add_matrix(struct merge_plan *plan, struct state_ud *matrix) {
+	if (plan->matrix_count == plan->matrix_capacity) {
+		size_t capacity = plan->matrix_capacity == 0 ? 4 :
+			plan->matrix_capacity * 2;
+		struct state_ud **matrices = skynet_realloc(plan->matrices,
+			capacity * sizeof(*matrices));
+		plan->matrices = matrices;
+		plan->matrix_capacity = capacity;
+	}
+	plan->matrices[plan->matrix_count++] = matrix;
+}
+
+static int
+same_value(lua_State *L, int left, int right) {
+	if (lua_type(L, left) == LUA_TNUMBER &&
+		lua_type(L, right) == LUA_TNUMBER &&
+		lua_isinteger(L, left) != lua_isinteger(L, right))
+		return 0;
+	return lua_rawequal(L, left, right);
+}
+
+static int
+build_swaps(lua_State *L, int stable_index, int staging_index,
+		struct merge_job *job) {
+	stable_index = lua_absindex(L, stable_index);
+	staging_index = lua_absindex(L, staging_index);
+	if (!lua_checkstack(L, 4))
+		return merge_fail(job, "ShareTable tree is too deep");
+	Table *stable = (Table *)lua_topointer(L, stable_index);
+	Table *staging = (Table *)lua_topointer(L, staging_index);
+	int direct_changed = 0;
+
+	lua_pushnil(L);
+	while (lua_next(L, staging_index) != 0) {
+		lua_pushvalue(L, -2);
+		lua_rawget(L, stable_index);
+		if (lua_type(L, -1) == LUA_TTABLE &&
+			lua_type(L, -2) == LUA_TTABLE) {
+			if (!build_swaps(L, -1, -2, job)) {
+				lua_pop(L, 3);
+				return 0;
+			}
+			lua_pushvalue(L, -3);
+			lua_pushvalue(L, -2);
+			lua_rawset(L, staging_index);
+		} else if (!same_value(L, -1, -2)) {
+			direct_changed = 1;
+		}
+		lua_pop(L, 2);
+	}
+
+	lua_pushnil(L);
+	while (lua_next(L, stable_index) != 0) {
+		lua_pushvalue(L, -2);
+		lua_rawget(L, staging_index);
+		if (lua_isnil(L, -1))
+			direct_changed = 1;
+		lua_pop(L, 2);
+	}
+
+	if (direct_changed)
+		plan_add_swap(job, stable, staging);
+	return 1;
+}
+
+static void
+mark_shared_direct(lua_State *L, int index) {
+	index = lua_absindex(L, index);
+	lua_pushnil(L);
+	while (lua_next(L, index) != 0) {
+		if (lua_type(L, -2) == LUA_TSTRING)
+			lua_sharestring(L, -2);
+		if (lua_type(L, -1) == LUA_TSTRING)
+			lua_sharestring(L, -1);
+		lua_pop(L, 1);
+	}
+	makeshared((Table *)lua_topointer(L, index));
+}
+
+static void
+mark_candidate_shared(lua_State *L, const struct merge_job *job) {
+	for (size_t i = 0; i < job->seen_count; i++) {
+		Table *table = (Table *)job->seen_tables[i];
+		sethvalue2s(L, L->top.p, table);
+		api_incr_top(L);
+		mark_shared_direct(L, -1);
+		lua_pop(L, 1);
+	}
+}
+
+static int
+prepare_merge_entry(lua_State *L) {
+	struct merge_job *job = lua_touserdata(L, 1);
+	luaL_checktype(L, 2, LUA_TTABLE);
+	lua_settop(L, 2);
+
+	int candidate = 2;
+	if (!validate_table(L, candidate, job))
+		return luaL_error(L, "%s", job->error);
+	lua_clonetable(L, job->stable);
+	if (!build_swaps(L, -1, candidate, job))
+		return luaL_error(L, "%s", job->error);
+	lua_pop(L, 1);
+	mark_candidate_shared(L, job);
+	return 0;
+}
+
+static int
+raise_matrix_error(lua_State *L, lua_State *mL, const char *fallback) {
+	const char *error = lua_tostring(mL, -1);
+	lua_pushstring(L, error == NULL ? fallback : error);
+	lua_settop(mL, 1);
+	return lua_error(L);
+}
+
+static struct merge_plan *
+check_merge_plan(lua_State *L, int index);
+
+static int
+prepare_merge(lua_State *L) {
+	struct state_ud *ud = (struct state_ud *)luaL_checkudata(L, 1,
+		"BOXMATRIXSTATE");
+	if (ud->L == NULL)
+		return luaL_error(L, "matrix is closed");
+	if (ud->lease != 0)
+		return luaL_error(L, "matrix update is in progress");
+	void *buffer = lua_touserdata(L, 2);
+	lua_Integer size = luaL_checkinteger(L, 3);
+	lua_State *mL = ud->L;
+	lua_settop(mL, 1);
+	if (!lua_checkstack(mL, 3))
+		return luaL_error(L, "not enough stack for ShareTable candidate");
+	lua_pushcfunction(mL, luaseri_unpack);
+	lua_pushlightuserdata(mL, buffer);
+	lua_pushinteger(mL, size);
+	int status = lua_pcall(mL, 2, 1, 0);
+	lua_gc(mL, LUA_GCSTOP, 0);
+	G(mL)->gcstopem = 1;
+	if (status != LUA_OK)
+		return raise_matrix_error(L, mL, "ShareTable build failed");
+
+	const int new_plan = lua_isnoneornil(L, 4);
+	struct merge_plan *plan = new_plan ?
+		skynet_calloc(1, sizeof(*plan)) : check_merge_plan(L, 4);
+	const size_t initial_swap_count = plan->swap_count;
+	struct merge_job job;
+	memset(&job, 0, sizeof(job));
+	job.plan = plan;
+	job.stable = (Table *)lua_touserdata(mL, 1);
+	lua_pushcfunction(mL, prepare_merge_entry);
+	lua_pushlightuserdata(mL, &job);
+	lua_pushvalue(mL, 2);
+	if (lua_pcall(mL, 2, 0, 0) != LUA_OK) {
+		skynet_free(job.seen_tables);
+		plan->swap_count = initial_swap_count;
+		if (new_plan) {
+			skynet_free(plan->swaps);
+			skynet_free(plan);
+		}
+		return raise_matrix_error(L, mL, "ShareTable merge preparation failed");
+	}
+	lua_settop(mL, 1);
+	skynet_free(job.seen_tables);
+	plan_add_matrix(plan, ud);
+	ud->lease = 1;
+	lua_pushlightuserdata(L, plan);
+	lua_pushboolean(L, plan->swap_count != 0);
+	return 2;
+}
+
+static struct merge_plan *
+check_merge_plan(lua_State *L, int index) {
+	struct merge_plan *plan = lua_touserdata(L, index);
+	if (plan == NULL)
+		luaL_argerror(L, index, "merge plan expected");
+	return plan;
+}
+
+static int
+submit_merge(lua_State *L) {
+	struct merge_plan *plan = check_merge_plan(L, 1);
+	uint32_t destination = (uint32_t)luaL_checkinteger(L, 2);
+	struct skynet_worker_control_completion *completion =
+		skynet_malloc(sizeof(*completion));
+	completion->plan = plan;
+	struct skynet_worker_control_task task = {
+		.swaps = plan->swaps,
+		.swap_count = plan->swap_count,
+		.destination = destination,
+		.completion = completion,
+	};
+	enum skynet_worker_control_submit_result result =
+		skynet_worker_control_try_submit(&task);
+	if (result == SKYNET_WORKER_CONTROL_ACCEPTED) {
+		lua_pushboolean(L, 1);
+		return 1;
+	}
+	skynet_free(completion);
+	lua_pushboolean(L, 0);
+	if (result == SKYNET_WORKER_CONTROL_SHUTDOWN)
+		lua_pushliteral(L, "Worker Controller is shutting down");
+	else if (result == SKYNET_WORKER_CONTROL_NOT_READY)
+		lua_pushliteral(L, "Worker Controller is not ready");
+	else
+		lua_pushliteral(L, "Worker Controller is busy");
+	return 2;
+}
+
+static int
+finalize_merge(lua_State *L) {
+	struct merge_plan *plan = check_merge_plan(L, 1);
+	for (size_t i = 0; i < plan->matrix_count; i++)
+		plan->matrices[i]->lease = 0;
+	skynet_free(plan->matrices);
+	skynet_free(plan->swaps);
+	skynet_free(plan);
+	return 0;
+}
+
+static int
+unpack_completion(lua_State *L) {
+	const void *message = lua_touserdata(L, 1);
+	size_t size = (size_t)luaL_checkinteger(L, 2);
+	if (message == NULL || size != sizeof(struct skynet_worker_control_completion))
+		return luaL_error(L, "invalid Worker Controller completion");
+	const struct skynet_worker_control_completion *completion = message;
+	lua_pushlightuserdata(L, completion->plan);
+	if (completion->status == SKYNET_WORKER_CONTROL_COMMITTED) {
+		lua_pushboolean(L, 1);
+	} else if (completion->status == SKYNET_WORKER_CONTROL_TIMED_OUT) {
+		lua_pushboolean(L, 0);
+	} else {
+		return luaL_error(L, "invalid Worker Controller completion status");
+	}
+	return 2;
+}
 
 static int
 box_state(lua_State *L, lua_State *mL) {
 	struct state_ud *ud = (struct state_ud *)lua_newuserdatauv(L, sizeof(*ud), 0);
 	ud->L = mL;
+	ud->lease = 0;
 	if (luaL_newmetatable(L, "BOXMATRIXSTATE")) {
 		lua_pushvalue(L, -1);
 		lua_setfield(L, -2, "__index");
@@ -163,6 +510,8 @@ box_state(lua_State *L, lua_State *mL) {
 		lua_setfield(L, -2, "getptr");
 		lua_pushcfunction(L, get_size);
 		lua_setfield(L, -2, "size");
+		lua_pushcfunction(L, prepare_merge);
+		lua_setfield(L, -2, "prepare_merge");
 	}
 	lua_setmetatable(L, -2);
 
@@ -183,7 +532,6 @@ load_matrixfile(lua_State *L) {
 	lua_replace(L, 1);
 	if (lua_pcall(L, lua_gettop(L) - 1, 1, 0) != LUA_OK)
 		lua_error(L);
-	lua_gc(L, LUA_GCCOLLECT, 0);
 	lua_pushcfunction(L, make_matrix);
 	lua_insert(L, -2);
 	lua_call(L, 1, 1);
@@ -192,7 +540,11 @@ load_matrixfile(lua_State *L) {
 
 static int
 matrix_from_file(lua_State *L) {
+#if LUA_VERSION_NUM >= 505
 	lua_State *mL = lua_newstate(luaL_alloc, NULL, G(L)->seed);
+#else
+	lua_State *mL = luaL_newstate();
+#endif
 	if (mL == NULL) {
 		return luaL_error(L, "luaL_newstate failed");
 	}
@@ -245,9 +597,11 @@ luaopen_skynet_sharetable_core(lua_State *L) {
 	luaL_checkversion(L);
 	luaL_Reg l[] = {
 		{ "clone", clone_table },
-		{ "stackvalues", lco_stackvalues }, 
 		{ "matrix", matrix_from_file },
 		{ "is_sharedtable", lis_sharedtable },
+		{ "submit_merge", submit_merge },
+		{ "finalize_merge", finalize_merge },
+		{ "unpack_completion", unpack_completion },
 		{ NULL, NULL },
 	};
 	luaL_newlib(L, l);

--- a/lualib/skynet/sharetable.lua
+++ b/lualib/skynet/sharetable.lua
@@ -1,18 +1,35 @@
 local skynet = require "skynet"
 local service = require "skynet.service"
 local core = require "skynet.sharetable.core"
-local is_sharedtable = core.is_sharedtable
-local stackvalues = core.stackvalues
 
 local function sharetable_service()
 	local skynet = require "skynet"
 	local core = require "skynet.sharetable.core"
+	local Queue = require "skynet.queue"
+
+	local TABLE_SOURCE = [[
+		local unpack, ptr, len = ...
+		return unpack(ptr, len)
+	]]
 
 	local matrix = {}	-- all the matrix
 	local files = {}	-- filename : matrix
 	local clients = {}
+	local mutation_queue = Queue()
+	local pending = {}
 
 	local sharetable = {}
+
+	skynet.register_protocol {
+		name = "sharetable_completion",
+		id = skynet.PTYPE_SYSTEM,
+		unpack = core.unpack_completion,
+		dispatch = function(_, _, plan, committed)
+			local result = assert(pending[plan])
+			result.committed = committed
+			skynet.wakeup(plan)
+		end,
+	}
 
 	local function close_matrix(m)
 		if m == nil then
@@ -26,34 +43,111 @@ local function sharetable_service()
 		end
 	end
 
-	function sharetable.loadfile(source, filename, ...)
+	local function loadfile(filename, ...)
 		close_matrix(files[filename])
 		local m = core.matrix("@" .. filename, ...)
 		files[filename] = m
+	end
+
+	function sharetable.loadfile(_, filename, ...)
+		mutation_queue(loadfile, filename, ...)
 		skynet.ret()
 	end
 
-	function sharetable.loadstring(source, filename, datasource, ...)
+	local function loadstring(filename, datasource, ...)
 		close_matrix(files[filename])
 		local m = core.matrix(datasource, ...)
 		files[filename] = m
+	end
+
+	function sharetable.loadstring(_, filename, datasource, ...)
+		mutation_queue(loadstring, filename, datasource, ...)
 		skynet.ret()
 	end
 
 	local function loadtable(filename, ptr, len)
 		close_matrix(files[filename])
-		local m = core.matrix([[
-			local unpack, ptr, len = ...
-			return unpack(ptr, len)
-		]], skynet.unpack, ptr, len)
+		local m = core.matrix(TABLE_SOURCE, skynet.unpack, ptr, len)
 		files[filename] = m
 	end
 
-	function sharetable.loadtable(source, filename, ptr, len)
-		local ok, err = pcall(loadtable, filename, ptr, len)
+	function sharetable.loadtable(_, filename, ptr, len)
+		local ok, err = pcall(mutation_queue, loadtable, filename, ptr, len)
 		skynet.trash(ptr, len)
 		assert(ok, err)
 		skynet.ret()
+	end
+
+	local function commit_merge(plan, changed)
+		if not changed then
+			core.finalize_merge(plan)
+			return true
+		end
+
+		local result = {}
+		pending[plan] = result
+		local submitted, err = core.submit_merge(plan, skynet.self())
+		if not submitted then
+			pending[plan] = nil
+			core.finalize_merge(plan)
+			return false, err
+		end
+		skynet.wait(plan)
+		pending[plan] = nil
+		core.finalize_merge(plan)
+		if result.committed then
+			return true
+		end
+		return false, "ShareTable update timed out waiting for workers"
+	end
+
+	local function merge(values)
+		local plan
+		local function prepare_batch()
+			local changed = false
+			for i = 1, #values, 3 do
+				local filename = values[i]
+				local m = files[filename]
+				if not m then
+					error(string.format("ShareTable is not loaded: %s", filename), 0)
+				end
+				local result = table.pack(pcall(
+					m.prepare_merge, m, values[i + 1], values[i + 2], plan))
+				if not result[1] then
+					error(string.format("ShareTable merge failed: %s: %s",
+						filename, result[2]), 0)
+				end
+				plan, changed = table.unpack(result, 2, result.n)
+			end
+			return changed
+		end
+
+		local ok, changed = xpcall(prepare_batch, debug.traceback)
+		for i = 1, #values, 3 do
+			skynet.trash(values[i + 1], values[i + 2])
+		end
+		if not ok then
+			if plan then
+				core.finalize_merge(plan)
+			end
+			return false, changed
+		end
+		if not plan then
+			return true
+		end
+		return commit_merge(plan, changed)
+	end
+
+	local function run_merge(func, ...)
+		local ok, success, err = xpcall(func, debug.traceback, ...)
+		if not ok then
+			return false, success
+		end
+		return success, err
+	end
+
+	function sharetable.merge(_, values)
+		skynet.retpack(mutation_queue(run_merge, merge, values))
 	end
 
 	local function query_file(source, filename)
@@ -94,11 +188,11 @@ local function sharetable_service()
 
 	local function querylist(source, filenamelist)
 		local ptrList = {}
-        for _, filename in ipairs(filenamelist) do
-            if files[filename] then
-                ptrList[filename] = query_file(source, filename)
-            end
-        end
+		for _, filename in ipairs(filenamelist) do
+			if files[filename] then
+				ptrList[filename] = query_file(source, filename)
+			end
+		end
 		return ptrList
 	end
 
@@ -110,11 +204,11 @@ local function sharetable_service()
 		return ptrList
 	end
 
-    function sharetable.queryall(source, filenamelist)
+	function sharetable.queryall(source, filenamelist)
 		local queryFunc = filenamelist and querylist or queryall
 		local ptrList = queryFunc(source, filenamelist)
-        skynet.ret(skynet.pack(ptrList))
-    end
+		skynet.ret(skynet.pack(ptrList))
+	end
 
 	function sharetable.close(source)
 		local list = clients[source]
@@ -216,283 +310,47 @@ function sharetable.loadtable(filename, tbl)
 	skynet.call(sharetable.address, "lua", "loadtable", filename, skynet.pack(tbl))
 end
 
+function sharetable.merge(values)
+	assert(type(values) == "table", "ShareTable merge values must be a table")
+	for filename, value in pairs(values) do
+		assert(type(filename) == "string", "ShareTable merge name must be a string")
+		assert(type(value) == "table", "ShareTable merge value must be a table")
+	end
 
-local RECORD = {}
+	local packed = {}
+	local ok, err = xpcall(function()
+		for filename, value in pairs(values) do
+			local ptr, len = skynet.pack(value)
+			packed[#packed + 1] = filename
+			packed[#packed + 1] = ptr
+			packed[#packed + 1] = len
+		end
+	end, debug.traceback)
+	if not ok then
+		for i = 1, #packed, 3 do
+			skynet.trash(packed[i + 1], packed[i + 2])
+		end
+		error(err, 0)
+	end
+	if #packed == 0 then
+		return true
+	end
+	return skynet.call(sharetable.address, "lua", "merge", packed)
+end
 function sharetable.query(filename)
 	local newptr = skynet.call(sharetable.address, "lua", "query", filename)
 	if newptr then
-		local t = core.clone(newptr)
-		local map = RECORD[filename]
-		if not map then
-			map = {}
-			RECORD[filename] = map
-		end
-		map[t] = true
-		return t
+		return core.clone(newptr)
 	end
 end
 
 function sharetable.queryall(filenamelist)
-    local list, t, map = {}
-    local ptrList = skynet.call(sharetable.address, "lua", "queryall", filenamelist)
-    for filename, ptr in pairs(ptrList) do
-        t = core.clone(ptr)
-        map = RECORD[filename]
-        if not map then
-            map = {}
-            RECORD[filename] = map
-        end
-        map[t] = true
-        list[filename] = t
-    end
-    return list
-end
-
-local pairs = pairs
-local type = type
-local assert = assert
-local next = next
-local rawset = rawset
-local getuservalue = debug.getuservalue
-local setuservalue = debug.setuservalue
-local getupvalue = debug.getupvalue
-local setupvalue = debug.setupvalue
-local getlocal = debug.getlocal
-local setlocal = debug.setlocal
-local getinfo = debug.getinfo
-
-local NILOBJ = {}
-local function insert_replace(old_t, new_t, replace_map)
-    for k, ov in pairs(old_t) do
-        if type(ov) == "table" then
-            local nv = new_t[k]
-            if nv == nil then
-                nv = NILOBJ
-            end
-            assert(replace_map[ov] == nil)
-            replace_map[ov] = nv
-            nv = type(nv) == "table" and nv or NILOBJ
-            insert_replace(ov, nv, replace_map)
-        end
-    end
-    replace_map[old_t] = new_t
-    return replace_map
-end
-
-
-local function resolve_replace(replace_map)
-    local match = {}
-    local record_map = {}
-
-    local function getnv(v)
-        local nv = replace_map[v]
-        if nv then
-            if nv == NILOBJ then
-                return nil
-            end
-            return nv
-        end
-        assert(false)
-    end
-
-    local function match_value(v)
-        if v == nil or record_map[v] or is_sharedtable(v) then
-            return
-        end
-
-        local tv = type(v)
-        local f = match[tv]
-        if f then
-            record_map[v] = true
-            return f(v)
-        end
-    end
-
-    local function match_mt(v)
-        local mt = debug.getmetatable(v)
-        if mt then
-            local nv = replace_map[mt]
-            if nv then
-                nv = getnv(mt)
-                debug.setmetatable(v, nv)
-            else
-                return match_value(mt)
-            end
-        end
-    end
-
-    local function match_internmt()
-        local internal_types = {
-            pointer = debug.upvalueid(getnv, 1),
-            boolean = false,
-            str = "",
-            number = 42,
-            thread = coroutine.running(),
-            func = getnv,
-        }
-        for _,v in pairs(internal_types) do
-            match_mt(v)
-        end
-        return match_mt(nil)
-    end
-
-
-    local function match_table(t)
-        local keys = false
-        for k,v in next, t do
-            local tk = type(k)
-            if match[tk] then
-                keys = keys or {}
-                keys[#keys+1] = k
-            end
-
-            local nv = replace_map[v]
-            if nv then
-                nv = getnv(v)
-                rawset(t, k, nv)
-            else
-                match_value(v)
-            end
-        end
-
-        if keys then
-            for _, old_k in ipairs(keys) do
-                local new_k = replace_map[old_k]
-                if new_k then
-                    local value = rawget(t, old_k)
-                    new_k = getnv(old_k)
-                    rawset(t, old_k, nil)
-                    if new_k then
-                        rawset(t, new_k, value)
-                    end
-                else
-                    match_value(old_k)
-                end
-            end
-        end
-        return match_mt(t)
-    end
-
-    local function match_userdata(u)
-        local uv = getuservalue(u)
-        local nv = replace_map[uv]
-        if nv then
-            nv = getnv(uv)
-            setuservalue(u, nv)
-        end
-        return match_mt(u)
-    end
-
-    local function match_funcinfo(info)
-        local func = info.func
-        local nups = info.nups
-        for i=1,nups do
-            local name, upv = getupvalue(func, i)
-            local nv = replace_map[upv]
-            if nv then
-                nv = getnv(upv)
-                setupvalue(func, i, nv)
-            elseif upv then
-                match_value(upv)
-            end
-        end
-
-        local level = info.level
-        local curco = info.curco
-        if not level then
-            return
-        end
-        local i = 1
-        while true do
-            local name, v = getlocal(curco, level, i)
-            if name == nil then
-                break
-            end
-            if replace_map[v] then
-                local nv = getnv(v)
-                setlocal(curco, level, i, nv)
-            elseif v then
-                match_value(v)
-            end
-            i = i + 1
-        end
-    end
-
-    local function match_function(f)
-        local info = getinfo(f, "uf")
-        return match_funcinfo(info)
-    end
-
-    local function match_thread(co, level)
-        -- match stackvalues
-        local values = {}
-        local n = stackvalues(co, values)
-        for i=1,n do
-            local v = values[i]
-            match_value(v)
-        end
-
-        local uplevel = co == coroutine.running() and 1 or 0
-        level = level or 1
-        while true do
-            local info = getinfo(co, level, "uf")
-            if not info then
-                break
-            end
-            info.level = level + uplevel
-            info.curco = co
-            match_funcinfo(info)
-            level = level + 1
-        end
-    end
-
-    local function prepare_match()
-        local co = coroutine.running()
-        record_map[co] = true
-        record_map[match] = true
-        record_map[RECORD] = true
-        record_map[record_map] = true
-        record_map[replace_map] = true
-        record_map[insert_replace] = true
-        record_map[resolve_replace] = true
-        assert(getinfo(co, 3, "f").func == sharetable.update)
-        match_thread(co, 5) -- ignore match_thread and match_funcinfo frame
-    end
-
-    match["table"] = match_table
-    match["function"] = match_function
-    match["userdata"] = match_userdata
-    match["thread"] = match_thread
-
-    prepare_match()
-    match_internmt()
-
-    local root = debug.getregistry()
-    assert(replace_map[root] == nil)
-    match_table(root)
-end
-
-
-function sharetable.update(...)
-	local names = {...}
-	local replace_map = {}
-	for _, name in ipairs(names) do
-		local map = RECORD[name]
-		if map then
-			local new_t = sharetable.query(name)
-			for old_t,_ in pairs(map) do
-				if old_t ~= new_t then
-					insert_replace(old_t, new_t, replace_map)
-                    map[old_t] = nil
-				end
-			end
-		end
+	local list = {}
+	local ptrList = skynet.call(sharetable.address, "lua", "queryall", filenamelist)
+	for filename, ptr in pairs(ptrList) do
+		list[filename] = core.clone(ptr)
 	end
-
-    if next(replace_map) then
-        resolve_replace(replace_map)
-    end
+	return list
 end
 
 return sharetable
-

--- a/mingw.mk
+++ b/mingw.mk
@@ -62,7 +62,8 @@ LUA_CLIB_SKYNET = \
 SKYNET_SRC = skynet_main.c skynet_handle.c skynet_module.c skynet_mq.c \
   skynet_server.c skynet_start.c skynet_timer.c skynet_error.c \
   skynet_harbor.c skynet_env.c skynet_monitor.c skynet_socket.c socket_server.c \
-  mem_info.c malloc_hook.c skynet_daemon.c skynet_log.c
+  mem_info.c malloc_hook.c skynet_daemon.c skynet_log.c \
+  skynet_worker_control.c
 
 $(LUA_STATICLIB): 
 	@echo "Building Lua static library..."

--- a/skynet-src/skynet_handle.c
+++ b/skynet-src/skynet_handle.c
@@ -319,8 +319,8 @@ skynet_handle_init(int harbor, int thread) {
 
 	rwlock_init(&s->lock);
 
-	// Distributed reader slots: workers + monitor + timer + socket
-	s->rslot_count = thread + 3;
+	// Distributed reader slots: workers + monitor + timer + socket + controller
+	s->rslot_count = thread + 4;
 	size_t rslot_sz = (size_t)s->rslot_count * sizeof(struct handle_reader_slot);
 	s->rslots = (struct handle_reader_slot *)skynet_malloc(rslot_sz);
 	memset(s->rslots, 0, rslot_sz);

--- a/skynet-src/skynet_imp.h
+++ b/skynet-src/skynet_imp.h
@@ -19,6 +19,7 @@ struct skynet_config {
 #define THREAD_SOCKET 2
 #define THREAD_TIMER 3
 #define THREAD_MONITOR 4
+#define THREAD_WORKER_CONTROL 5
 
 void skynet_start(struct skynet_config * config);
 

--- a/skynet-src/skynet_server.c
+++ b/skynet-src/skynet_server.c
@@ -5,6 +5,7 @@
 #include "skynet_handle.h"
 #include "skynet_mq.h"
 #include "skynet_timer.h"
+#include "skynet_worker_control.h"
 #include "skynet_harbor.h"
 #include "skynet_env.h"
 #include "skynet_monitor.h"
@@ -331,6 +332,8 @@ skynet_context_message_dispatch(struct skynet_monitor *sm, struct message_queue 
 		}
 
 		skynet_monitor_trigger(sm, 0,0);
+		if (skynet_worker_control_stop_requested())
+			break;
 	}
 
 	assert(q == ctx->queue);

--- a/skynet-src/skynet_start.c
+++ b/skynet-src/skynet_start.c
@@ -5,6 +5,7 @@
 #include "skynet_handle.h"
 #include "skynet_module.h"
 #include "skynet_timer.h"
+#include "skynet_worker_control.h"
 #include "skynet_monitor.h"
 #include "skynet_socket.h"
 #include "skynet_daemon.h"
@@ -58,6 +59,14 @@ wakeup(struct monitor *m, int busy) {
 		// signal sleep worker, "spurious wakeup" is harmless
 		pthread_cond_signal(&m->cond);
 	}
+}
+
+static void
+wakeup_all_workers(void *ud) {
+	struct monitor *m = ud;
+	pthread_mutex_lock(&m->mutex);
+	pthread_cond_broadcast(&m->cond);
+	pthread_mutex_unlock(&m->mutex);
 }
 
 static void *
@@ -135,7 +144,10 @@ thread_timer(void *p) {
 	for (;;) {
 		skynet_updatetime();
 		skynet_socket_updatetime();
-		CHECK_ABORT
+		if (skynet_context_total() == 0) {
+			skynet_worker_control_request_shutdown();
+			break;
+		}
 		wakeup(m,m->count-1);
 		usleep(2500);
 		if (SIG) {
@@ -154,6 +166,15 @@ thread_timer(void *p) {
 }
 
 static void *
+thread_worker_control(void *p) {
+	(void)p;
+	skynet_initthread(THREAD_WORKER_CONTROL);
+	skynet_handle_register_thread();
+	skynet_worker_control_run();
+	return NULL;
+}
+
+static void *
 thread_worker(void *p) {
 	struct worker_parm *wp = p;
 	int id = wp->id;
@@ -162,11 +183,18 @@ thread_worker(void *p) {
 	struct skynet_monitor *sm = m->m[id];
 	skynet_initthread(THREAD_WORKER);
 	skynet_handle_register_thread();
+	skynet_worker_control_register_worker();
 	struct message_queue * q = NULL;
 	while (!m->quit) {
 		q = skynet_context_message_dispatch(sm, q, weight);
+		skynet_worker_control_checkpoint();
 		if (q == NULL) {
 			if (pthread_mutex_lock(&m->mutex) == 0) {
+				if (skynet_worker_control_stop_requested()) {
+					pthread_mutex_unlock(&m->mutex);
+					skynet_worker_control_checkpoint();
+					continue;
+				}
 				++ m->sleep;
 				// "spurious wakeup" is harmless,
 				// because skynet_context_message_dispatch() can be call at any time.
@@ -185,7 +213,7 @@ thread_worker(void *p) {
 
 static void
 start(int thread) {
-	pthread_t pid[thread+3];
+	pthread_t pid[thread+4];
 
 	struct monitor *m = skynet_malloc(sizeof(*m));
 	memset(m, 0, sizeof(*m));
@@ -205,10 +233,12 @@ start(int thread) {
 		fprintf(stderr, "Init cond error");
 		exit(1);
 	}
+	skynet_worker_control_init(thread, wakeup_all_workers, m);
 
 	create_thread(&pid[0], thread_monitor, m);
 	create_thread(&pid[1], thread_timer, m);
 	create_thread(&pid[2], thread_socket, m);
+	create_thread(&pid[3], thread_worker_control, NULL);
 
 	static int weight[] = {
 		-1, -1, -1, -1, 0, 0, 0, 0,
@@ -224,13 +254,14 @@ start(int thread) {
 		} else {
 			wp[i].weight = 0;
 		}
-		create_thread(&pid[i+3], thread_worker, &wp[i]);
+		create_thread(&pid[i+4], thread_worker, &wp[i]);
 	}
 
-	for (i=0;i<thread+3;i++) {
+	for (i=0;i<thread+4;i++) {
 		pthread_join(pid[i], NULL);
 	}
 
+	skynet_worker_control_destroy();
 	free_monitor(m);
 }
 

--- a/skynet-src/skynet_worker_control.c
+++ b/skynet-src/skynet_worker_control.c
@@ -1,0 +1,317 @@
+#include "skynet_worker_control.h"
+
+#include "atomic.h"
+#include "skynet.h"
+#include "skynet_mq.h"
+#include "skynet_server.h"
+
+#include <lstate.h>
+#include <ltable.h>
+#include <ltm.h>
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define WORKER_STOP_TIMEOUT_US UINT64_C(2000000)
+#define MICROSECONDS_PER_SECOND UINT64_C(1000000)
+
+static uint64_t
+monotonic_time_us(void) {
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	return (uint64_t)now.tv_sec * MICROSECONDS_PER_SECOND +
+		(uint64_t)now.tv_nsec / UINT64_C(1000);
+}
+
+struct worker_control {
+	int worker_count;
+	int registered_count;
+
+	pthread_mutex_t mutex;
+	pthread_cond_t cond;
+	skynet_worker_control_wake_all wake_all;
+	void *wake_ud;
+
+	ATOM_INT stop_requested;
+	bool thread_ready;
+	bool shutdown;
+
+	enum skynet_worker_control_state state;
+	int parked_count;
+	struct skynet_worker_control_task task;
+};
+
+static struct worker_control *CONTROL;
+
+static void
+abort_initialization(const char *message) {
+	fputs(message, stderr);
+	abort();
+}
+
+static void
+check_pthread_initialization(int err, const char *message) {
+	if (err != 0)
+		abort_initialization(message);
+}
+
+void
+skynet_worker_control_init(int worker_count,
+		skynet_worker_control_wake_all wake_all, void *wake_ud) {
+	if (worker_count <= 0)
+		abort_initialization("invalid worker controller initialization\n");
+
+	struct worker_control *c = skynet_calloc(1, sizeof(*c));
+	c->worker_count = worker_count;
+	c->wake_all = wake_all;
+	c->wake_ud = wake_ud;
+	c->state = SKYNET_WORKER_CONTROL_EMPTY;
+	ATOM_INIT(&c->stop_requested, false);
+
+	check_pthread_initialization(pthread_mutex_init(&c->mutex, NULL),
+		"worker controller mutex init failed\n");
+#if defined(__APPLE__) || defined(_WIN32)
+	check_pthread_initialization(pthread_cond_init(&c->cond, NULL),
+		"worker controller cond init failed\n");
+#else
+	pthread_condattr_t attr;
+	check_pthread_initialization(pthread_condattr_init(&attr),
+		"worker controller condattr init failed\n");
+	check_pthread_initialization(
+		pthread_condattr_setclock(&attr, CLOCK_MONOTONIC),
+		"worker controller cond clock init failed\n");
+	check_pthread_initialization(pthread_cond_init(&c->cond, &attr),
+		"worker controller cond init failed\n");
+	pthread_condattr_destroy(&attr);
+#endif
+	CONTROL = c;
+}
+
+void
+skynet_worker_control_destroy(void) {
+	struct worker_control *c = CONTROL;
+	pthread_cond_destroy(&c->cond);
+	pthread_mutex_destroy(&c->mutex);
+	skynet_free(c);
+	CONTROL = NULL;
+}
+
+void
+skynet_worker_control_register_worker(void) {
+	struct worker_control *c = CONTROL;
+	pthread_mutex_lock(&c->mutex);
+	c->registered_count++;
+	pthread_mutex_unlock(&c->mutex);
+}
+
+int
+skynet_worker_control_stop_requested(void) {
+	return ATOM_LOAD(&CONTROL->stop_requested);
+}
+
+void
+skynet_worker_control_checkpoint(void) {
+	struct worker_control *c = CONTROL;
+	if (!ATOM_LOAD(&c->stop_requested))
+		return;
+
+	pthread_mutex_lock(&c->mutex);
+	if (c->state != SKYNET_WORKER_CONTROL_STOPPING) {
+		pthread_mutex_unlock(&c->mutex);
+		return;
+	}
+
+	c->parked_count++;
+	if (c->parked_count == c->worker_count)
+		pthread_cond_broadcast(&c->cond);
+	while (c->state == SKYNET_WORKER_CONTROL_STOPPING ||
+		c->state == SKYNET_WORKER_CONTROL_EXECUTING) {
+		pthread_cond_wait(&c->cond, &c->mutex);
+	}
+	c->parked_count--;
+	pthread_cond_signal(&c->cond);
+	pthread_mutex_unlock(&c->mutex);
+}
+
+enum skynet_worker_control_submit_result
+skynet_worker_control_try_submit(const struct skynet_worker_control_task *task) {
+	struct worker_control *c = CONTROL;
+	pthread_mutex_lock(&c->mutex);
+
+	enum skynet_worker_control_submit_result result;
+	if (c->shutdown) {
+		result = SKYNET_WORKER_CONTROL_SHUTDOWN;
+	} else if (!c->thread_ready ||
+		c->registered_count != c->worker_count) {
+		result = SKYNET_WORKER_CONTROL_NOT_READY;
+	} else if (c->state != SKYNET_WORKER_CONTROL_EMPTY) {
+		result = SKYNET_WORKER_CONTROL_BUSY;
+	} else {
+		c->task = *task;
+		c->state = SKYNET_WORKER_CONTROL_PENDING;
+		result = SKYNET_WORKER_CONTROL_ACCEPTED;
+		pthread_cond_signal(&c->cond);
+	}
+
+	pthread_mutex_unlock(&c->mutex);
+	return result;
+}
+
+void
+skynet_worker_control_request_shutdown(void) {
+	struct worker_control *c = CONTROL;
+	pthread_mutex_lock(&c->mutex);
+	c->shutdown = true;
+	pthread_cond_signal(&c->cond);
+	pthread_mutex_unlock(&c->mutex);
+}
+
+static void
+swap_sharetable_storage(Table *stable, Table *staging) {
+	const lu_byte lsizenode = stable->lsizenode;
+	Node *node = stable->node;
+
+#if LUA_VERSION_NUM == 504
+	Node *lastfree = stable->lastfree;
+	const unsigned int alimit = stable->alimit;
+	TValue *array = stable->array;
+	const int bitras = stable->flags & BITRAS;
+	stable->lastfree = staging->lastfree;
+	stable->alimit = staging->alimit;
+	stable->array = staging->array;
+	stable->flags = cast_byte((stable->flags & ~BITRAS) |
+		(staging->flags & BITRAS));
+	staging->lastfree = lastfree;
+	staging->alimit = alimit;
+	staging->array = array;
+	staging->flags = cast_byte((staging->flags & ~BITRAS) | bitras);
+#elif LUA_VERSION_NUM == 505
+	const unsigned int asize = stable->asize;
+	Value *array = stable->array;
+	const int bitdummy = stable->flags & BITDUMMY;
+	stable->asize = staging->asize;
+	stable->array = staging->array;
+	stable->flags = cast_byte((stable->flags & NOTBITDUMMY) |
+		(staging->flags & BITDUMMY));
+	staging->asize = asize;
+	staging->array = array;
+	staging->flags = cast_byte((staging->flags & NOTBITDUMMY) | bitdummy);
+#else
+#error unsupported Lua version
+#endif
+
+	stable->lsizenode = staging->lsizenode;
+	stable->node = staging->node;
+	staging->lsizenode = lsizenode;
+	staging->node = node;
+	invalidateTMcache(stable);
+}
+
+static void
+handoff_completion(const struct skynet_worker_control_task *task,
+		enum skynet_worker_control_completion_status status) {
+	task->completion->status = (uint32_t)status;
+	struct skynet_message message;
+	message.source = 0;
+	message.session = 0;
+	message.data = task->completion;
+	message.sz = sizeof(*task->completion) |
+		((size_t)PTYPE_SYSTEM << MESSAGE_TYPE_SHIFT);
+	if (skynet_context_push(task->destination, &message) != 0) {
+		skynet_error(NULL, "ERROR: Worker controller completion handoff "
+			"failed; ShareTable service is unavailable");
+		/*
+		 * All parked workers have already been released and the task slot is
+		 * empty. The retired owner can no longer finalize its plan or submit
+		 * more work, so abandon that plan and keep the process available.
+		 */
+		skynet_free(task->completion);
+	}
+}
+
+static int
+wait_until_locked(struct worker_control *c, uint64_t deadline_us) {
+#if defined(__APPLE__) || defined(_WIN32)
+	const uint64_t now_us = monotonic_time_us();
+	if (deadline_us <= now_us)
+		return ETIMEDOUT;
+	const uint64_t remaining_us = deadline_us - now_us;
+	struct timespec timeout;
+	timeout.tv_sec = (time_t)(remaining_us / UINT64_C(1000000));
+	timeout.tv_nsec = (long)((remaining_us % UINT64_C(1000000)) * 1000);
+	return pthread_cond_timedwait_relative_np(&c->cond, &c->mutex, &timeout);
+#else
+	struct timespec deadline;
+	deadline.tv_sec = (time_t)(deadline_us / UINT64_C(1000000));
+	deadline.tv_nsec = (long)((deadline_us % UINT64_C(1000000)) * 1000);
+	return pthread_cond_timedwait(&c->cond, &c->mutex, &deadline);
+#endif
+}
+
+void
+skynet_worker_control_run(void) {
+	struct worker_control *c = CONTROL;
+	pthread_mutex_lock(&c->mutex);
+	c->thread_ready = true;
+
+	for (;;) {
+		while (c->state == SKYNET_WORKER_CONTROL_EMPTY && !c->shutdown)
+			pthread_cond_wait(&c->cond, &c->mutex);
+		if (c->state == SKYNET_WORKER_CONTROL_EMPTY && c->shutdown) {
+			pthread_mutex_unlock(&c->mutex);
+			return;
+		}
+
+		c->parked_count = 0;
+		c->state = SKYNET_WORKER_CONTROL_STOPPING;
+		ATOM_STORE(&c->stop_requested, true);
+		const uint64_t deadline_us =
+			monotonic_time_us() + WORKER_STOP_TIMEOUT_US;
+
+		/* Never hold controller.mutex while acquiring monitor.mutex. */
+		pthread_mutex_unlock(&c->mutex);
+		c->wake_all(c->wake_ud);
+		pthread_mutex_lock(&c->mutex);
+
+		while (c->parked_count != c->worker_count) {
+			if (wait_until_locked(c, deadline_us) != 0)
+				break;
+		}
+
+		enum skynet_worker_control_completion_status status;
+		if (c->parked_count == c->worker_count) {
+			c->state = SKYNET_WORKER_CONTROL_EXECUTING;
+			pthread_mutex_unlock(&c->mutex);
+			for (size_t i = 0; i < c->task.swap_count; i++) {
+				const struct skynet_sharetable_storage_swap *swap =
+					&c->task.swaps[i];
+				swap_sharetable_storage(swap->stable, swap->staging);
+			}
+			pthread_mutex_lock(&c->mutex);
+			status = SKYNET_WORKER_CONTROL_COMMITTED;
+		} else {
+			status = SKYNET_WORKER_CONTROL_TIMED_OUT;
+		}
+
+		c->state = SKYNET_WORKER_CONTROL_RELEASING;
+		ATOM_STORE(&c->stop_requested, false);
+		pthread_cond_broadcast(&c->cond);
+		while (c->parked_count != 0)
+			pthread_cond_wait(&c->cond, &c->mutex);
+		const struct skynet_worker_control_task task = c->task;
+		memset(&c->task, 0, sizeof(c->task));
+		c->state = SKYNET_WORKER_CONTROL_EMPTY;
+		pthread_mutex_unlock(&c->mutex);
+
+		/* Completion is a normal MQ message and must be sent after STW release. */
+		handoff_completion(&task, status);
+		c->wake_all(c->wake_ud);
+
+		pthread_mutex_lock(&c->mutex);
+	}
+}

--- a/skynet-src/skynet_worker_control.h
+++ b/skynet-src/skynet_worker_control.h
@@ -1,0 +1,67 @@
+#ifndef SKYNET_WORKER_CONTROL_H
+#define SKYNET_WORKER_CONTROL_H
+
+#include <lobject.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+enum skynet_worker_control_submit_result {
+	SKYNET_WORKER_CONTROL_ACCEPTED = 0,
+	SKYNET_WORKER_CONTROL_BUSY = 1,
+	SKYNET_WORKER_CONTROL_SHUTDOWN = 2,
+	SKYNET_WORKER_CONTROL_NOT_READY = 3,
+};
+
+enum skynet_worker_control_completion_status {
+	SKYNET_WORKER_CONTROL_COMMITTED = 0,
+	SKYNET_WORKER_CONTROL_TIMED_OUT = 1,
+};
+
+enum skynet_worker_control_state {
+	SKYNET_WORKER_CONTROL_EMPTY = 0,
+	SKYNET_WORKER_CONTROL_PENDING,
+	SKYNET_WORKER_CONTROL_STOPPING,
+	SKYNET_WORKER_CONTROL_EXECUTING,
+	SKYNET_WORKER_CONTROL_RELEASING,
+};
+
+struct skynet_sharetable_storage_swap {
+	Table *stable;
+	Table *staging;
+};
+
+/* PTYPE_SYSTEM payload delivered after all parked workers leave the safe point. */
+struct skynet_worker_control_completion {
+	void *plan;
+	uint32_t status;
+};
+
+/* A successful submit keeps swaps and plan alive until completion delivery.
+ * They are deliberately abandoned if the destination service is retired. */
+struct skynet_worker_control_task {
+	const struct skynet_sharetable_storage_swap *swaps;
+	size_t swap_count;
+	uint32_t destination;
+	struct skynet_worker_control_completion *completion;
+};
+
+typedef void (*skynet_worker_control_wake_all)(void *ud);
+
+void skynet_worker_control_init(int worker_count,
+		skynet_worker_control_wake_all wake_all, void *wake_ud);
+void skynet_worker_control_destroy(void);
+
+/* Called only by the dedicated THREAD_WORKER_CONTROL thread. */
+void skynet_worker_control_run(void);
+
+void skynet_worker_control_register_worker(void);
+void skynet_worker_control_checkpoint(void);
+int skynet_worker_control_stop_requested(void);
+
+enum skynet_worker_control_submit_result
+skynet_worker_control_try_submit(const struct skynet_worker_control_task *task);
+
+void skynet_worker_control_request_shutdown(void);
+
+#endif

--- a/test/config.sharetable
+++ b/test/config.sharetable
@@ -1,0 +1,10 @@
+include "../examples/config.path"
+
+thread = 4
+logger = nil
+logpath = "."
+harbor = 0
+start = "testsharetable"
+bootstrap = "snlua bootstrap"
+cpath = root .. "cservice/?.so"
+profile = false

--- a/test/testsharetable.lua
+++ b/test/testsharetable.lua
@@ -1,38 +1,269 @@
-local skynet = require "skynet"
+local skynet = require "skynet.manager"
 local sharetable = require "skynet.sharetable"
 
-local function queryall_test()
-	sharetable.loadtable("test_one", {["message"] = "hello one", x = 1, 1})
-	sharetable.loadtable("test_two", {["message"] = "hello two", x = 2, 2})
-	sharetable.loadtable("test_three", {["message"] = "hello three", x = 3, 3})
-	local list = sharetable.queryall({"test_one", "test_two"})
-	for filename, tbl in pairs(list) do
-		for k, v in pairs(tbl) do
-			print(filename, k, v)
-		end
-	end
+local MAIN_NAME = "merge_main"
+local OTHER_NAME = "merge_other"
+local SOURCE_NAME = "merge_source"
+local META_NAME = "merge_meta"
+local CONSUMER_COUNT = 8
 
-	print("test queryall default")
-	local defaultlist = sharetable.queryall()
-	for filename, tbl in pairs(defaultlist) do
-		for k, v in pairs(tbl) do
-			print(filename, k, v)
-		end
+local busy_started = false
+
+local function count_pairs(value)
+	local count = 0
+	for _ in pairs(value) do
+		count = count + 1
+	end
+	return count
+end
+
+local function expect_write_rejected(write)
+	local ok = pcall(write)
+	assert(not ok, "shared table write unexpectedly succeeded")
+end
+
+local function initial_main()
+	return {
+		1,
+		2,
+		3,
+		keep = "before",
+		removed = { value = "removed" },
+		replaced = { value = "replaced" },
+		nested = {
+			value = 1,
+			deep = { marker = "before" },
+		},
+	}
+end
+
+local function grown_main()
+	local value = {
+		keep = "after",
+		added = true,
+		replaced = 17,
+		nested = {
+			value = 2,
+			deep = { marker = "after" },
+			branch = { leaf = true },
+		},
+	}
+	for i = 1, 512 do
+		value[i] = i * 3
+		value["hash_" .. i] = i * 5
+	end
+	return value
+end
+
+local function shrunk_main()
+	return {
+		3,
+		6,
+		9,
+		keep = "final",
+		replaced = 17,
+		nested = {
+			value = 3,
+			deep = { marker = "final" },
+		},
+	}
+end
+
+local function start_consumers()
+	local consumers = {}
+	for i = 1, CONSUMER_COUNT do
+		local service = skynet.newservice("testsharetable_consumer")
+		assert(skynet.call(service, "lua", "hold", MAIN_NAME))
+		consumers[i] = service
+	end
+	return consumers
+end
+
+local function check_consumers(consumers, version, length)
+	for _, service in ipairs(consumers) do
+		assert(skynet.call(service, "lua", "check", version, length))
 	end
 end
 
-skynet.start(function()
-	-- You can also use sharetable.loadfile / sharetable.loadstring
-	sharetable.loadtable ("test", { x=1,y={ 'hello world' },['hello world'] = true })
-	local t = sharetable.query("test")
-	for k,v in pairs(t) do
-		print(k,v)
+local function test_merge()
+	sharetable.loadtable(MAIN_NAME, initial_main())
+	sharetable.loadtable(OTHER_NAME, {
+		version = 1,
+		number = 1,
+		child = { value = "before" },
+	})
+
+	local root = assert(sharetable.query(MAIN_NAME))
+	local nested = root.nested
+	local deep = nested.deep
+	local removed = root.removed
+	local replaced = root.replaced
+	local other = assert(sharetable.query(OTHER_NAME))
+	local other_child = other.child
+	local consumers = start_consumers()
+
+	local ok, err = sharetable.merge {
+		[MAIN_NAME] = grown_main(),
+		[OTHER_NAME] = {
+			version = 2,
+			number = 1.0,
+			child = { value = "after" },
+			added = true,
+		},
+	}
+	assert(ok, err)
+
+	assert(rawequal(root, assert(sharetable.query(MAIN_NAME))))
+	assert(rawequal(nested, root.nested))
+	assert(rawequal(deep, root.nested.deep))
+	assert(rawequal(other, assert(sharetable.query(OTHER_NAME))))
+	assert(rawequal(other_child, other.child))
+	assert(root.keep == "after" and root.added)
+	assert(root.removed == nil and root.replaced == 17)
+	assert(removed.value == "removed")
+	assert(replaced.value == "replaced")
+	assert(root.nested.value == 2 and root.nested.deep.marker == "after")
+	assert(root.nested.branch.leaf)
+	assert(#root == 512 and rawlen(root) == 512)
+	assert(count_pairs(root) == 1028)
+	assert(rawget(root, 256) == 768)
+	assert(next(root) ~= nil)
+	for i = 1, 512 do
+		assert(root[i] == i * 3)
+		assert(root["hash_" .. i] == i * 5)
 	end
-	sharetable.loadstring ("test", "return { ... }", 1,2,3)
-	local t = sharetable.query("test")
-	for k,v in pairs(t) do
-		print(k,v)
+	assert(other.version == 2 and other.child.value == "after" and other.added)
+	assert(math.type(other.number) == "float")
+	check_consumers(consumers, 2, 512)
+
+	expect_write_rejected(function()
+		root.forbidden = true
+	end)
+	expect_write_rejected(function()
+		rawset(root, "forbidden", true)
+	end)
+	expect_write_rejected(function()
+		setmetatable(root, {})
+	end)
+
+	ok, err = sharetable.merge {
+		[MAIN_NAME] = grown_main(),
+		[OTHER_NAME] = {
+			version = 2,
+			number = 1.0,
+			child = { value = "after" },
+			added = true,
+		},
+	}
+	assert(ok, err)
+	assert(rawequal(root, assert(sharetable.query(MAIN_NAME))))
+	assert(rawequal(nested, root.nested) and rawequal(deep, root.nested.deep))
+
+	sharetable.loadstring(SOURCE_NAME, [[
+		return {
+			version = 1,
+			child = { value = "source" },
+		}
+	]])
+	local source = assert(sharetable.query(SOURCE_NAME))
+	local source_child = source.child
+	ok, err = sharetable.merge {
+		[SOURCE_NAME] = {
+			version = 2,
+			child = { value = "merged" },
+		},
+	}
+	assert(ok, err)
+	assert(rawequal(source, assert(sharetable.query(SOURCE_NAME))))
+	assert(rawequal(source_child, source.child))
+	assert(source.version == 2 and source.child.value == "merged")
+
+	sharetable.loadtable(META_NAME, { marker = true })
+	local shared_metatable = assert(sharetable.query(META_NAME))
+	local target = setmetatable({}, shared_metatable)
+	assert(target.answer == nil)
+	ok, err = sharetable.merge {
+		[META_NAME] = {
+			marker = true,
+			__index = { answer = 42 },
+		},
+	}
+	assert(ok, err)
+	assert(target.answer == 42)
+	ok, err = sharetable.merge {
+		[META_NAME] = { marker = true },
+	}
+	assert(ok, err)
+	assert(target.answer == nil)
+
+	local missing_ok, missing_err = sharetable.merge {
+		missing_sharetable = { value = true },
+	}
+	assert(not missing_ok and tostring(missing_err):find("not loaded", 1, true))
+
+	local infinite_ok, infinite_err = sharetable.merge {
+		[MAIN_NAME] = { value = math.huge },
+	}
+	assert(not infinite_ok and tostring(infinite_err):find("finite", 1, true))
+	assert(root.keep == "after" and #root == 512)
+
+	local cycle = {}
+	cycle.self = cycle
+	local cycle_ok = pcall(sharetable.merge, {
+		[MAIN_NAME] = cycle,
+	})
+	assert(not cycle_ok)
+
+	local function_ok = pcall(sharetable.merge, {
+		[MAIN_NAME] = { callback = function() end },
+	})
+	assert(not function_ok)
+
+	busy_started = false
+	local busy_worker = skynet.newservice("testsharetable_busy_worker")
+	skynet.send(busy_worker, "lua", "block", skynet.self(), 400)
+	while not busy_started do
+		skynet.sleep(1)
 	end
 
-	queryall_test()
+	local timeout_ok, timeout_err = sharetable.merge {
+		[MAIN_NAME] = shrunk_main(),
+	}
+	assert(not timeout_ok)
+	assert(tostring(timeout_err):find("timed out", 1, true))
+	assert(root.keep == "after" and #root == 512 and root.nested.value == 2)
+
+	skynet.sleep(220)
+	ok, err = sharetable.merge {
+		[MAIN_NAME] = shrunk_main(),
+	}
+	assert(ok, err)
+	assert(rawequal(root, assert(sharetable.query(MAIN_NAME))))
+	assert(rawequal(nested, root.nested) and rawequal(deep, root.nested.deep))
+	assert(#root == 3 and rawlen(root) == 3)
+	assert(root.keep == "final" and root.nested.value == 3)
+	assert(root.nested.deep.marker == "final")
+	assert(root.added == nil and root.hash_1 == nil and root.nested.branch == nil)
+	check_consumers(consumers, 3, 3)
+
+	local all = sharetable.queryall({ MAIN_NAME, OTHER_NAME, SOURCE_NAME })
+	assert(rawequal(root, all[MAIN_NAME]))
+	assert(rawequal(other, all[OTHER_NAME]))
+	assert(rawequal(source, all[SOURCE_NAME]))
+end
+
+skynet.start(function()
+	skynet.dispatch("lua", function(_, _, command)
+		assert(command == "busy_started")
+		busy_started = true
+	end)
+
+	local ok, err = xpcall(test_merge, debug.traceback)
+	if ok then
+		skynet.error("ShareTable atomic merge test: PASS")
+	else
+		skynet.error("ShareTable atomic merge test: FAIL\n", err)
+	end
+	skynet.sleep(1)
+	skynet.abort()
 end)

--- a/test/testsharetable_busy_worker.lua
+++ b/test/testsharetable_busy_worker.lua
@@ -1,0 +1,15 @@
+local skynet = require "skynet"
+
+skynet.start(function()
+	skynet.dispatch("lua", function(_, _, command, target, duration)
+		assert(command == "block")
+		target = assert(tonumber(target))
+		duration = assert(tonumber(duration))
+		skynet.send(target, "lua", "busy_started")
+		local deadline = skynet.now() + duration
+		while skynet.now() < deadline do
+			-- Keep this worker inside the current callback.
+		end
+		skynet.exit()
+	end)
+end)

--- a/test/testsharetable_consumer.lua
+++ b/test/testsharetable_consumer.lua
@@ -1,0 +1,32 @@
+local skynet = require "skynet"
+local sharetable = require "skynet.sharetable"
+
+local root
+local nested
+local deep
+local filename
+
+skynet.start(function()
+	skynet.dispatch("lua", function(_, _, command, ...)
+		if command == "hold" then
+			filename = ...
+			root = assert(sharetable.query(filename))
+			nested = root.nested
+			deep = nested.deep
+			skynet.retpack(true)
+		elseif command == "check" then
+			local version, length = ...
+			local current = assert(sharetable.query(filename))
+			assert(rawequal(root, current))
+			assert(rawequal(nested, current.nested))
+			assert(rawequal(deep, current.nested.deep))
+			assert(current.nested.value == version)
+			assert(#current == length and rawlen(current) == length)
+			collectgarbage()
+			assert(current.nested.value == version)
+			skynet.retpack(true)
+		else
+			error("unknown command: " .. tostring(command))
+		end
+	end)
+end)


### PR DESCRIPTION
## 背景与现有瓶颈

当前 ShareTable 的更新流程是先发布一个新 matrix，再由每个持有者 service 调用 `sharetable.update`。

为了让业务代码已经缓存的 root 和嵌套 table 引用切换到新 matrix，`sharetable.update` 需要从 Lua registry 开始遍历该 service 的对象图，并检查或改写 table、function/upvalue、coroutine stack、userdata uservalue 和 metatable 中的旧引用。

这会带来几个问题：

- 更新成本取决于持有该 ShareTable 的 service 数量以及每个 Lua VM 的对象图规模，而不仅是本次变化的数据量；
- service 数量增加时，逐 service 更新的耗时近似线性增长；
- 并行调用虽然能缩短部分墙钟时间，但完整的 VM 扫描工作并没有消失，会消耗大量 worker CPU；
- 各 service 独立完成切换，更新期间可能同时存在读取旧版本和新版本的 service，无法提供一次更新的全局原子可见性。

## 本次方案

新增生产端更新接口：

```lua
local ok, err = sharetable.merge {
    ["config_a"] = new_config_a,
    ["config_b"] = new_config_b,
}
```

更新分为准备和提交两个阶段：

1. ShareTable service 在各 matrix 的 owner Lua State 中构造并校验 candidate；
2. 递归比较 stable graph 和 candidate graph；
3. 对新旧两侧同路径的 table 保留原有 `Table *`，只生成其 array/hash storage 的交换计划；
4. 一个 `merge` 中的多个 matrix 合并为同一个提交计划；
5. Worker Controller 请求所有 worker 在当前 callback 结束后进入 safe point；
6. 全部 worker 停下后，一次性交换计划中所有 table 的 storage；
7. 交换完成后恢复 worker，再通知 ShareTable service 返回结果。

STW 阶段只执行预先生成的 storage swap，不调用 Lua API、allocator、free、I/O、日志或业务 callback。

这样可以得到以下语义：

- root table 以及新旧两侧同路径的嵌套 table 保持原有 identity；
- 业务长期缓存的 table 引用可以直接看到更新后的内容；
- `rawget`、`next`、`pairs`、`ipairs`、`rawlen`、`#` 和 C `lua_next` 仍然走原生 Lua table 路径；
- 一个 `merge` 中的全部 matrix 对所有 worker 原子可见，只会观察到完整旧版本或完整新版本；
- 更新成本主要随数据量增长，不再随 holder service 数量线性放大。

## 失败与超时语义

所有可能失败或需要分配内存的工作都在第一条 storage 写入前完成。

- candidate 构造、数据校验或 diff 失败时，已发布 graph 保持不变；
- no-op merge 不触发 STW；
- Controller busy、尚未 ready 或正在 shutdown 时直接返回失败；
- Controller 最多等待 2 秒让全部 worker 到达 safe point；
- 等待超时时不会执行任何 storage swap，已经停下的 worker 会全部恢复；
- Controller 不抢占正在执行的 callback，因此长时间不返回的 callback 可能导致本次 merge 超时；
- ShareTable 的 load 和 merge 操作通过 service 内队列串行执行。

## 性能结果

测试环境为 24 workers、1000 个独立 consumer service、100 万个全部变化的 integer value。

| 实现 | 更新墙钟 p50 | CPU p50 |
|---|---:|---:|
| 现有逐 service `sharetable.update` | 30.293 s | 30.808 s |
| 本次 `sharetable.merge` | 136.920 ms | 139.531 ms |

固定 100 万项时：

- 现有方案从 1 个 service 的 107.073 ms 增长到 1000 个 service 的 30.293 s；
- 新方案从 1 个 service 的 129.994 ms 变化到 1000 个 service 的 136.920 ms。

更新后的读取仍是原生 table 读取，与普通 table 没有可分辨的系统性性能差异。未发生更新时，新增 worker checkpoint 也没有观察到稳定的消息吞吐回退。

一次 100 万项全量更新后的逻辑内存增长为 19.63 MiB，与现有更新方案接近。candidate 和换出的历史 storage 会保留在 matrix owner 中，直到 matrix 关闭。

## API 与使用边界

- `loadfile`、`loadstring`、`loadtable`、`query` 和 `queryall` 保持不变；
- consumer 侧的 `sharetable.update` 由生产端的 `sharetable.merge` 取代；
- 缓存的 scalar 或 string 不会自动变化；
- 某个 table 路径被删除或改为非 table 后，业务已经缓存的旧 table 仍指向原内容；
- 不应在遍历可 merge 的 shared table 时跨 yield；
- merge candidate 必须是无 alias、无 cycle、无 metatable 的有限 table tree，且只能包含 ShareTable 支持的 key/value 类型。